### PR TITLE
Configurable RMS detector selection with metadata default

### DIFF
--- a/slac_measurements/wires/analysis.py
+++ b/slac_measurements/wires/analysis.py
@@ -62,11 +62,14 @@ class WireMeasurementAnalysis(slac_measurements.beam_profile.BeamProfileAnalysis
         fit_result = self._fit_data_by_profile(profile_measurements=profile_measurements)
         rms_sizes = self._get_rms_sizes(fit_result, detector=rms_detector)
 
+        metadata = self.collection_result.metadata
+        metadata.rms_detector = rms_detector if rms_detector is not None else metadata.default_detector
+
         return WireMeasurementAnalysisResult(
             fit_result=fit_result,
             rms_sizes=rms_sizes,
             collection_result=self.collection_result,
-            metadata=self.collection_result.metadata,
+            metadata=metadata,
             profiles=profile_measurements,
         )
 

--- a/slac_measurements/wires/analysis.py
+++ b/slac_measurements/wires/analysis.py
@@ -34,13 +34,21 @@ class WireMeasurementAnalysis(slac_measurements.beam_profile.BeamProfileAnalysis
     model_config = ConfigDict(arbitrary_types_allowed=True)
     fitting_method: Literal["gaussian", "asymmetric_gaussian", "super_gaussian"] = "gaussian"
 
-    def analyze(self) -> WireMeasurementAnalysisResult:
+    def analyze(
+        self, rms_detector: str | None = None
+    ) -> WireMeasurementAnalysisResult:
         """
         Organize data by profile, fit beam profile curves, extract RMS sizes.
 
         Uses the configured fitting method (set via fitting_method parameter)
         to fit each detector's data. Available methods: 'gaussian',
         'asymmetric_gaussian', 'super_gaussian'.
+
+        Parameters
+        ----------
+        rms_detector : str, optional
+            Detector name used to extract RMS sizes. If omitted, uses
+            ``collection_result.metadata.default_detector``.
 
         Returns
         -------
@@ -52,7 +60,7 @@ class WireMeasurementAnalysis(slac_measurements.beam_profile.BeamProfileAnalysis
         profile_measurements = self._organize_data_by_profile(profile_indices)
 
         fit_result = self._fit_data_by_profile(profile_measurements=profile_measurements)
-        rms_sizes = self._get_rms_sizes(fit_result)
+        rms_sizes = self._get_rms_sizes(fit_result, detector=rms_detector)
 
         return WireMeasurementAnalysisResult(
             fit_result=fit_result,
@@ -341,30 +349,45 @@ class WireMeasurementAnalysis(slac_measurements.beam_profile.BeamProfileAnalysis
 
         return profile_indices
 
-    def _get_rms_sizes(self, fit_result: dict) -> tuple[float | None, float | None]:
+    def _get_rms_sizes(
+        self, fit_result: dict, detector: str | None = None
+    ) -> tuple[float | None, float | None]:
         """
         Extract RMS beam sizes from fit results.
 
         Computes RMS sizes from x and y profile fits using the
-        default detector.
+        requested detector, defaulting to the configured default detector.
 
         Parameters:
             fit_result (dict): Fit results from fit_data_by_profile().
+            detector (str | None): Detector name to use for RMS extraction.
 
         Returns:
             tuple[float | None, float | None]: (x_rms, y_rms) in meters.
             Returns (None, None) if neither profile is present.
         """
-        default_det = self.collection_result.metadata.default_detector
+        available_detectors = self.collection_result.metadata.detectors
+        selected_detector = (
+            self.collection_result.metadata.default_detector
+            if detector is None
+            else detector
+        )
+
+        if selected_detector not in available_detectors:
+            raise ValueError(
+                f"Detector '{selected_detector}' is not available in "
+                f"metadata.detectors={available_detectors}."
+            )
+
         x_rms = None
         y_rms = None
 
         if "x" in fit_result:
-            x_fit = fit_result["x"].detectors[default_det]
+            x_fit = fit_result["x"].detectors[selected_detector]
             x_rms = x_fit.sigma
 
         if "y" in fit_result:
-            y_fit = fit_result["y"].detectors[default_det]
+            y_fit = fit_result["y"].detectors[selected_detector]
             y_rms = y_fit.sigma
 
         return (x_rms, y_rms)

--- a/slac_measurements/wires/analysis_results.py
+++ b/slac_measurements/wires/analysis_results.py
@@ -1,5 +1,7 @@
 from typing import Dict
 
+import numpy as np
+
 from pydantic import BaseModel, ConfigDict
 
 from slac_measurements.beam_profile import (
@@ -49,6 +51,49 @@ class WireMeasurementAnalysisResult(BeamProfileMeasurementResult):
     collection_result: WireMeasurementCollectionResult
     profiles: Dict[str, ProfileMeasurement]
 
+    def set_rms_detector(self, detector: str | None = None) -> None:
+        """Mutate the result to use a different detector for RMS sizes.
+
+        Parameters
+        ----------
+        detector : str, optional
+            Detector name used to derive ``rms_sizes``. If omitted, the
+            metadata ``default_detector`` is used.
+        """
+
+        metadata = self.collection_result.metadata
+        selected_detector = (
+            metadata.default_detector if detector is None else detector
+        )
+
+        if selected_detector not in metadata.detectors:
+            raise ValueError(
+                f"Detector '{selected_detector}' is not available in "
+                f"metadata.detectors={metadata.detectors}."
+            )
+
+        x_rms = self._get_profile_rms(profile="x", detector=selected_detector)
+        y_rms = self._get_profile_rms(profile="y", detector=selected_detector)
+
+        self.rms_sizes = np.array([x_rms, y_rms], dtype=object)
+        self.metadata.rms_detector = selected_detector
+        self.collection_result.metadata.rms_detector = selected_detector
+
+    def _get_profile_rms(
+        self, profile: str, detector: str
+    ) -> float | None:
+        """Return the RMS size for a profile/detector pair, if present."""
+        if profile not in self.fit_result:
+            return None
+
+        if detector not in self.fit_result[profile].detectors:
+            raise ValueError(
+                f"Detector '{detector}' is not available in fit_result "
+                f"for profile '{profile}'."
+            )
+
+        return self.fit_result[profile].detectors[detector].sigma
+
     def __repr__(self) -> str:
         """Return a compact string representation of the analysis result."""
         meta = self.collection_result.metadata
@@ -97,7 +142,6 @@ class WireMeasurementAnalysisResult(BeamProfileMeasurementResult):
         # reuse imports locally to avoid adding h5py/np at top-level when
         # the module is imported purely for type information
         import h5py
-        import numpy as np
 
         with h5py.File(filepath, "w") as f:
             # store the collection result under its own subgroup so that
@@ -176,7 +220,6 @@ def load_from_h5(filepath: str) -> WireMeasurementAnalysisResult:
     """
 
     import h5py
-    import numpy as np
 
     # first load the collection result using the existing loader by
     # temporarily writing the subgroup to a temporary file-like object.

--- a/slac_measurements/wires/analysis_results.py
+++ b/slac_measurements/wires/analysis_results.py
@@ -109,6 +109,7 @@ class WireMeasurementAnalysisResult(BeamProfileMeasurementResult):
             f"wire_name='{meta.wire_name}', "
             f"beampath='{meta.beampath}', "
             f"rms_sizes={rms_sizes_repr}, "
+            f"rms_detector='{meta.rms_detector}', "
             f"profiles={profile_count}, "
             f"fit_profiles={fit_profile_count}, "
             f"detectors={detector_count}, "

--- a/slac_measurements/wires/buffer.py
+++ b/slac_measurements/wires/buffer.py
@@ -48,6 +48,7 @@ def reserve_buffer(
     elif beampath.startswith("CU"):
         return _reserve_edef_buffer(
             name=name,
+            beampath=beampath,
             user=user,
             n_measurements=_calculate_buffer_points(pulses, beam_rate),
             logger=logger,
@@ -122,14 +123,25 @@ def _reserve_bsa_buffer(
 
 def _reserve_edef_buffer(
     name: str,
+    beampath: str,
     user: str,
     n_measurements: int,
     logger: logging.Logger = None,
 ):
+    
+    def _choose_beamcode(beampath):
+        if beampath.startswith("CU_HXR"):
+            return 1
+        elif beampath.startswith("CU_SXR"):
+            return 2
+        else:
+            raise BufferError(f"Unrecognized beampath for eDef: {beampath}")
+
     import edef
 
     buf = edef.EventDefinition(name=name, user=user)
     buf.n_measurements = n_measurements
+    buf.beamcode = _choose_beamcode(beampath)
     if logger:
         logger.info("Reserved eDef Buffer %s.", buf.number)
     return buf

--- a/slac_measurements/wires/collection.py
+++ b/slac_measurements/wires/collection.py
@@ -1,7 +1,6 @@
 import logging
 import time
 from datetime import datetime
-from importlib.resources import files
 from typing import Optional
 
 import numpy as np
@@ -20,9 +19,6 @@ from slac_measurements.wires.collection_results import (
 _DATE = datetime.now().strftime("%Y%m%d")
 _LOG_FILENAME = f"ws_log_{_DATE}.txt"
 _LOGGER_NAME = "wire_scan_logger"
-_WIRE_LBLMS_LOCATION = files("slac_db").joinpath(
-    "package_data", "wire_lblms.yaml"
-)
 _WIRE_TOLERANCE = 250  # microns
 
 
@@ -202,23 +198,10 @@ class WireMeasurementCollection(slac_measurements.beam_profile.BeamProfileMeasur
         """
         Make additional metadata.
         """
-        def _load_yaml_config() -> Optional[dict]:
-            import yaml
-
-            file_to_open = _WIRE_LBLMS_LOCATION
-
-            if file_to_open.exists() is False:
-                msg = f"YAML config file {file_to_open} not found."
-                self.logger.error(msg)
-                return None
-
-            with file_to_open.open("r") as f:
-                wire_lblms = yaml.safe_load(f)
-                return wire_lblms
-
         def _get_default_detector() -> str:
-            lblm_config = _load_yaml_config()
-            if lblm_config is None:
+            default_detector = self.my_wire.metadata.default_detector
+
+            if not default_detector:
                 if not self.detectors:
                     msg = (
                         "No detectors available from wire metadata; "
@@ -227,9 +210,9 @@ class WireMeasurementCollection(slac_measurements.beam_profile.BeamProfileMeasur
                     self.logger.error(msg)
                     raise RuntimeError(msg)
                 return self.detectors[0]
-            else:
-                default_detector = lblm_config[self.my_wire.name]
-                return default_detector
+
+            # Metadata may be stored as "<name>:<area>"; analysis expects the device name key.
+            return default_detector.split(":", 1)[0]
 
         def _get_scan_ranges():
             return {

--- a/slac_measurements/wires/collection_results.py
+++ b/slac_measurements/wires/collection_results.py
@@ -14,6 +14,7 @@ class MeasurementMetadata(BaseModel):
     beampath: str
     detectors: list[str]
     default_detector: str
+    rms_detector: Optional[str] = None
     scan_ranges: Dict[str, Tuple[int, int]]
     timestamp: datetime
     active_profiles: list[str]

--- a/slac_measurements/wires/collection_results.py
+++ b/slac_measurements/wires/collection_results.py
@@ -85,6 +85,8 @@ class WireMeasurementCollectionResult(BeamProfileCollectionResult):
         group.attrs["area"] = meta.area
         group.attrs["beampath"] = meta.beampath
         group.attrs["default_detector"] = meta.default_detector
+        if meta.rms_detector is not None:
+            group.attrs["rms_detector"] = meta.rms_detector
         group.attrs["timestamp"] = meta.timestamp.isoformat()
         group.attrs["active_profiles"] = meta.active_profiles
         group.attrs["install_angle"] = meta.install_angle
@@ -159,6 +161,7 @@ def _load_metadata(group: h5py.Group) -> MeasurementMetadata:
     area = group.attrs["area"]
     beampath = group.attrs["beampath"]
     default_detector = group.attrs["default_detector"]
+    rms_detector = group.attrs.get("rms_detector", None)
     timestamp_str = group.attrs["timestamp"]
     timestamp = datetime.fromisoformat(timestamp_str)
     active_profiles = group.attrs["active_profiles"]
@@ -182,6 +185,7 @@ def _load_metadata(group: h5py.Group) -> MeasurementMetadata:
         beampath=beampath,
         detectors=detectors,
         default_detector=default_detector,
+        rms_detector=rms_detector,
         scan_ranges=scan_ranges,
         timestamp=timestamp,
         active_profiles=active_profiles,

--- a/slac_measurements/wires/scan.py
+++ b/slac_measurements/wires/scan.py
@@ -35,6 +35,7 @@ class WireBeamProfileMeasurement(
         fitting_method: Literal[
             "gaussian", "asymmetric_gaussian", "super_gaussian"
         ] = "gaussian",
+        rms_detector: Optional[str] = None,
     ) -> WireMeasurementAnalysisResult:
         """
         Instantiate a WireMeasurementCollection, run the scan, analyze, and
@@ -48,6 +49,9 @@ class WireBeamProfileMeasurement(
             Fit model used by the downstream wire-scan analysis. Supported
             values are ``"gaussian"``, ``"asymmetric_gaussian"``, and
             ``"super_gaussian"``.
+        rms_detector : str, optional
+            Detector name to use when extracting RMS sizes. If omitted,
+            the collection metadata default detector is used.
 
         Returns
         -------
@@ -59,9 +63,16 @@ class WireBeamProfileMeasurement(
             beampath=self.beampath,
         )
         self.collection_result = collection.measure(scan_type=scan_type)
-        return self.analyze(fitting_method=fitting_method)
+        return self.analyze(
+            fitting_method=fitting_method,
+            rms_detector=rms_detector,
+        )
 
-    def analyze(self, fitting_method) -> WireMeasurementAnalysisResult:
+    def analyze(
+        self,
+        fitting_method,
+        rms_detector: Optional[str] = None,
+    ) -> WireMeasurementAnalysisResult:
         """
         Analyze the most recently collected wire-scan data.
 
@@ -70,6 +81,9 @@ class WireBeamProfileMeasurement(
         fitting_method : str, optional
             Fit model used by wire-scan analysis. If omitted, uses the
             instance default ``self.fitting_method``, Gaussian.
+        rms_detector : str, optional
+            Detector name to use when extracting RMS sizes. If omitted,
+            the collection metadata default detector is used.
 
         Returns
         -------
@@ -92,4 +106,4 @@ class WireBeamProfileMeasurement(
             collection_result=self.collection_result,
             fitting_method=fitting_method,
         )
-        return analysis.analyze()
+        return analysis.analyze(rms_detector=rms_detector)

--- a/slac_measurements/wires/scan.py
+++ b/slac_measurements/wires/scan.py
@@ -63,7 +63,10 @@ class WireBeamProfileMeasurement(
             beampath=self.beampath,
         )
         self.collection_result = collection.measure(scan_mode=scan_mode)
-        return self.analyze(fitting_method=fitting_method)
+        return self.analyze(
+            fitting_method=fitting_method,
+            rms_detector=rms_detector,
+        )
 
     def analyze(
         self,

--- a/tests/test_wire_scan.py
+++ b/tests/test_wire_scan.py
@@ -114,33 +114,33 @@ class WireBeamProfileMeasurementTest(TestCase):
         )
         mock_analysis.analyze.assert_called_once_with(rms_detector=None)
 
-    @patch("slac_measurements.wires.scan.WireMeasurementAnalysis")
-    def test_measure_passes_rms_detector_override(self, mock_analysis_cls):
-        mock_analysis = mock_analysis_cls.return_value
-        mock_analysis.analyze.return_value = "analysis-result"
+    # measure() constructs WireMeasurementCollection internally, so we patch
+    # it to keep this unit test isolated from collection setup behavior.
+    @patch("slac_measurements.wires.scan.WireMeasurementCollection")
+    def test_measure_passes_rms_detector_override(self, mock_collection_cls):
+        mock_collection_cls.return_value.measure.return_value = "collection-result"
 
-        with patch(
-            "slac_measurements.wires.scan.WireMeasurementCollection"
-        ) as mock_collection_cls:
-            mock_collection = mock_collection_cls.return_value
-            mock_collection.measure.return_value = "collection-result"
+        measurement = WireBeamProfileMeasurement(
+            beam_profile_device=self._make_wire_device(),
+            beampath="TEST",
+        )
 
-            measurement = WireBeamProfileMeasurement(
-                beam_profile_device=self._make_wire_device(),
-                beampath="TEST",
-            )
-
-            result = measurement.measure(
+        with patch.object(
+            WireBeamProfileMeasurement,
+            "analyze",
+            autospec=True,
+            return_value="analysis-result",
+        ) as mock_analyze:
+            measurement.measure(
                 fitting_method="gaussian",
                 rms_detector="D2",
             )
 
-        self.assertEqual(result, "analysis-result")
-        mock_analysis_cls.assert_called_once_with(
-            collection_result="collection-result",
+        mock_analyze.assert_called_once_with(
+            measurement,
             fitting_method="gaussian",
+            rms_detector="D2",
         )
-        mock_analysis.analyze.assert_called_once_with(rms_detector="D2")
 
     def test_analyze_raises_if_no_collection_result(self):
         measurement = WireBeamProfileMeasurement(

--- a/tests/test_wire_scan.py
+++ b/tests/test_wire_scan.py
@@ -136,10 +136,11 @@ class WireBeamProfileMeasurementTest(TestCase):
                 rms_detector="D2",
             )
 
-        mock_analyze.assert_called_once_with(
-            measurement,
-            fitting_method="gaussian",
-            rms_detector="D2",
+        mock_analyze.assert_called_once()
+        self.assertIs(mock_analyze.call_args.args[0], measurement)
+        self.assertEqual(
+            mock_analyze.call_args.kwargs,
+            {"fitting_method": "gaussian", "rms_detector": "D2"},
         )
 
     def test_analyze_raises_if_no_collection_result(self):

--- a/tests/test_wire_scan.py
+++ b/tests/test_wire_scan.py
@@ -112,6 +112,35 @@ class WireBeamProfileMeasurementTest(TestCase):
             collection_result=measurement.collection_result,
             fitting_method="super_gaussian",
         )
+        mock_analysis.analyze.assert_called_once_with(rms_detector=None)
+
+    @patch("slac_measurements.wires.scan.WireMeasurementAnalysis")
+    def test_measure_passes_rms_detector_override(self, mock_analysis_cls):
+        mock_analysis = mock_analysis_cls.return_value
+        mock_analysis.analyze.return_value = "analysis-result"
+
+        with patch(
+            "slac_measurements.wires.scan.WireMeasurementCollection"
+        ) as mock_collection_cls:
+            mock_collection = mock_collection_cls.return_value
+            mock_collection.measure.return_value = "collection-result"
+
+            measurement = WireBeamProfileMeasurement(
+                beam_profile_device=self._make_wire_device(),
+                beampath="TEST",
+            )
+
+            result = measurement.measure(
+                fitting_method="gaussian",
+                rms_detector="D2",
+            )
+
+        self.assertEqual(result, "analysis-result")
+        mock_analysis_cls.assert_called_once_with(
+            collection_result="collection-result",
+            fitting_method="gaussian",
+        )
+        mock_analysis.analyze.assert_called_once_with(rms_detector="D2")
 
     def test_analyze_raises_if_no_collection_result(self):
         measurement = WireBeamProfileMeasurement(

--- a/tests/test_wire_scan_analysis.py
+++ b/tests/test_wire_scan_analysis.py
@@ -17,6 +17,46 @@ from slac_measurements.wires.collection_results import (
 )
 
 
+def _make_detector_fit(
+    sigma: float,
+    *,
+    mean: float = 0.0,
+    amplitude: float = 1.0,
+    offset: float = 0.0,
+    curve: np.ndarray | None = None,
+    positions: np.ndarray | None = None,
+) -> DetectorFit:
+    return DetectorFit(
+        mean=mean,
+        sigma=sigma,
+        amplitude=amplitude,
+        offset=offset,
+        curve=np.array([1.0, 2.0]) if curve is None else curve,
+        positions=np.array([0.0, 1.0]) if positions is None else positions,
+    )
+
+
+def _make_fit_result(
+    sigma_map: dict[str, dict[str, float]],
+    *,
+    curve: np.ndarray | None = None,
+    positions: np.ndarray | None = None,
+) -> dict[str, FitResult]:
+    return {
+        profile: FitResult(
+            detectors={
+                detector: _make_detector_fit(
+                    sigma,
+                    curve=curve,
+                    positions=positions,
+                )
+                for detector, sigma in detector_sigmas.items()
+            }
+        )
+        for profile, detector_sigmas in sigma_map.items()
+    }
+
+
 class TestGetMonotonicIndices(TestCase):
     """Tests for the _get_monotonic_indices static method logic."""
 
@@ -280,32 +320,10 @@ class TestWireMeasurementAnalysisOtherMethods(TestCase):
 
     def test_get_rms_sizes_returns_expected_detector_sigmas(self):
         analysis = self._make_analysis(default_detector="D1")
-        fit_result = {
-            "x": FitResult(
-                detectors={
-                    "D1": DetectorFit(
-                        mean=0.0,
-                        sigma=1.25,
-                        amplitude=10.0,
-                        offset=0.0,
-                        curve=np.array([1.0, 2.0]),
-                        positions=np.array([0.0, 1.0]),
-                    )
-                }
-            ),
-            "y": FitResult(
-                detectors={
-                    "D1": DetectorFit(
-                        mean=0.0,
-                        sigma=2.5,
-                        amplitude=8.0,
-                        offset=0.0,
-                        curve=np.array([1.0, 2.0]),
-                        positions=np.array([0.0, 1.0]),
-                    )
-                }
-            ),
-        }
+        fit_result = _make_fit_result({
+            "x": {"D1": 1.25},
+            "y": {"D1": 2.5},
+        })
 
         x_rms, y_rms = analysis._get_rms_sizes(fit_result)
 
@@ -317,48 +335,10 @@ class TestWireMeasurementAnalysisOtherMethods(TestCase):
             default_detector="D1",
             detectors=["D1", "D2"],
         )
-        fit_result = {
-            "x": FitResult(
-                detectors={
-                    "D1": DetectorFit(
-                        mean=0.0,
-                        sigma=1.25,
-                        amplitude=10.0,
-                        offset=0.0,
-                        curve=np.array([1.0, 2.0]),
-                        positions=np.array([0.0, 1.0]),
-                    ),
-                    "D2": DetectorFit(
-                        mean=0.0,
-                        sigma=3.5,
-                        amplitude=11.0,
-                        offset=0.0,
-                        curve=np.array([1.0, 2.0]),
-                        positions=np.array([0.0, 1.0]),
-                    ),
-                }
-            ),
-            "y": FitResult(
-                detectors={
-                    "D1": DetectorFit(
-                        mean=0.0,
-                        sigma=2.5,
-                        amplitude=8.0,
-                        offset=0.0,
-                        curve=np.array([1.0, 2.0]),
-                        positions=np.array([0.0, 1.0]),
-                    ),
-                    "D2": DetectorFit(
-                        mean=0.0,
-                        sigma=4.5,
-                        amplitude=9.0,
-                        offset=0.0,
-                        curve=np.array([1.0, 2.0]),
-                        positions=np.array([0.0, 1.0]),
-                    ),
-                }
-            ),
-        }
+        fit_result = _make_fit_result({
+            "x": {"D1": 1.25, "D2": 3.5},
+            "y": {"D1": 2.5, "D2": 4.5},
+        })
 
         x_rms, y_rms = analysis._get_rms_sizes(fit_result, detector="D2")
 
@@ -367,20 +347,7 @@ class TestWireMeasurementAnalysisOtherMethods(TestCase):
 
     def test_get_rms_sizes_handles_missing_profiles(self):
         analysis = self._make_analysis(default_detector="D1")
-        fit_result = {
-            "x": FitResult(
-                detectors={
-                    "D1": DetectorFit(
-                        mean=0.0,
-                        sigma=1.1,
-                        amplitude=9.0,
-                        offset=0.0,
-                        curve=np.array([1.0]),
-                        positions=np.array([0.0]),
-                    )
-                }
-            )
-        }
+        fit_result = _make_fit_result({"x": {"D1": 1.1}})
 
         x_rms, y_rms = analysis._get_rms_sizes(fit_result)
 
@@ -410,18 +377,7 @@ class TestWireMeasurementAnalysisOtherMethods(TestCase):
             )
         }
         expected_fit_result = {
-            "x": FitResult(
-                detectors={
-                    "D1": DetectorFit(
-                        mean=0.5,
-                        sigma=1.0,
-                        amplitude=5.0,
-                        offset=0.0,
-                        curve=np.array([1.0, 2.0]),
-                        positions=np.array([0.0, 1.0]),
-                    )
-                }
-            )
+            "x": FitResult(detectors={"D1": _make_detector_fit(1.0, mean=0.5, amplitude=5.0)})
         }
 
         with patch.object(analysis, "_get_profile_range_indices", return_value=expected_indices) as mock_idx, patch.object(
@@ -463,48 +419,12 @@ class TestWireMeasurementAnalysisResult(TestCase):
             raw_data={"WIRE": np.array([0.0, 1.0])},
             metadata=metadata,
         )
-        fit_result = {
-            "x": FitResult(
-                detectors={
-                    "D1": DetectorFit(
-                        mean=0.0,
-                        sigma=1.25,
-                        amplitude=10.0,
-                        offset=0.0,
-                        curve=np.array([1.0, 2.0]),
-                        positions=np.array([0.0, 1.0]),
-                    ),
-                    "D2": DetectorFit(
-                        mean=0.0,
-                        sigma=3.5,
-                        amplitude=11.0,
-                        offset=0.0,
-                        curve=np.array([1.0, 2.0]),
-                        positions=np.array([0.0, 1.0]),
-                    ),
-                }
-            ),
-            "y": FitResult(
-                detectors={
-                    "D1": DetectorFit(
-                        mean=0.0,
-                        sigma=2.5,
-                        amplitude=8.0,
-                        offset=0.0,
-                        curve=np.array([1.0, 2.0]),
-                        positions=np.array([0.0, 1.0]),
-                    ),
-                    "D2": DetectorFit(
-                        mean=0.0,
-                        sigma=4.5,
-                        amplitude=9.0,
-                        offset=0.0,
-                        curve=np.array([1.0, 2.0]),
-                        positions=np.array([0.0, 1.0]),
-                    ),
-                }
-            ),
-        }
+        fit_result = _make_fit_result(
+            {
+                "x": {"D1": 1.25, "D2": 3.5},
+                "y": {"D1": 2.5, "D2": 4.5},
+            }
+        )
 
         return WireMeasurementAnalysisResult(
             fit_result=fit_result,
@@ -514,33 +434,37 @@ class TestWireMeasurementAnalysisResult(TestCase):
             metadata=metadata,
         )
 
-    def test_set_rms_detector_updates_rms_sizes_and_metadata(self):
-        result = self._make_result()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._result_template = cls._make_result()
 
-        result.set_rms_detector("D2")
+    def setUp(self):
+        # Use a deep copy of one shared template so tests remain isolated.
+        self.result = self._result_template.model_copy(deep=True)
+
+    def test_set_rms_detector_updates_rms_sizes_and_metadata(self):
+        self.result.set_rms_detector("D2")
 
         np.testing.assert_array_equal(
-            np.asarray(result.rms_sizes),
+            np.asarray(self.result.rms_sizes),
             np.array([3.5, 4.5], dtype=object),
         )
-        self.assertEqual(result.metadata.rms_detector, "D2")
-        self.assertEqual(result.collection_result.metadata.rms_detector, "D2")
+        self.assertEqual(self.result.metadata.rms_detector, "D2")
+        self.assertEqual(self.result.collection_result.metadata.rms_detector, "D2")
 
     def test_set_rms_detector_uses_default_when_detector_omitted(self):
-        result = self._make_result()
-        result.metadata.rms_detector = "D2"
-        result.collection_result.metadata.rms_detector = "D2"
+        self.result.metadata.rms_detector = "D2"
+        self.result.collection_result.metadata.rms_detector = "D2"
 
-        result.set_rms_detector()
+        self.result.set_rms_detector()
 
         np.testing.assert_array_equal(
-            np.asarray(result.rms_sizes),
+            np.asarray(self.result.rms_sizes),
             np.array([1.25, 2.5], dtype=object),
         )
-        self.assertEqual(result.metadata.rms_detector, "D1")
+        self.assertEqual(self.result.metadata.rms_detector, "D1")
 
     def test_set_rms_detector_raises_for_unknown_detector(self):
-        result = self._make_result()
-
         with self.assertRaises(ValueError):
-            result.set_rms_detector("D3")
+            self.result.set_rms_detector("D3")

--- a/tests/test_wire_scan_analysis.py
+++ b/tests/test_wire_scan_analysis.py
@@ -311,6 +311,59 @@ class TestWireMeasurementAnalysisOtherMethods(TestCase):
         self.assertEqual(x_rms, 1.25)
         self.assertEqual(y_rms, 2.5)
 
+    def test_get_rms_sizes_uses_requested_detector_override(self):
+        analysis = self._make_analysis(
+            default_detector="D1",
+            detectors=["D1", "D2"],
+        )
+        fit_result = {
+            "x": FitResult(
+                detectors={
+                    "D1": DetectorFit(
+                        mean=0.0,
+                        sigma=1.25,
+                        amplitude=10.0,
+                        offset=0.0,
+                        curve=np.array([1.0, 2.0]),
+                        positions=np.array([0.0, 1.0]),
+                    ),
+                    "D2": DetectorFit(
+                        mean=0.0,
+                        sigma=3.5,
+                        amplitude=11.0,
+                        offset=0.0,
+                        curve=np.array([1.0, 2.0]),
+                        positions=np.array([0.0, 1.0]),
+                    ),
+                }
+            ),
+            "y": FitResult(
+                detectors={
+                    "D1": DetectorFit(
+                        mean=0.0,
+                        sigma=2.5,
+                        amplitude=8.0,
+                        offset=0.0,
+                        curve=np.array([1.0, 2.0]),
+                        positions=np.array([0.0, 1.0]),
+                    ),
+                    "D2": DetectorFit(
+                        mean=0.0,
+                        sigma=4.5,
+                        amplitude=9.0,
+                        offset=0.0,
+                        curve=np.array([1.0, 2.0]),
+                        positions=np.array([0.0, 1.0]),
+                    ),
+                }
+            ),
+        }
+
+        x_rms, y_rms = analysis._get_rms_sizes(fit_result, detector="D2")
+
+        self.assertEqual(x_rms, 3.5)
+        self.assertEqual(y_rms, 4.5)
+
     def test_get_rms_sizes_handles_missing_profiles(self):
         analysis = self._make_analysis(default_detector="D1")
         fit_result = {
@@ -332,6 +385,12 @@ class TestWireMeasurementAnalysisOtherMethods(TestCase):
 
         self.assertEqual(x_rms, 1.1)
         self.assertIsNone(y_rms)
+
+    def test_get_rms_sizes_raises_for_unknown_detector(self):
+        analysis = self._make_analysis(detectors=["D1", "D2"])
+
+        with self.assertRaises(ValueError):
+            analysis._get_rms_sizes({}, detector="D3")
 
     def test_analyze_orchestrates_helper_methods_and_returns_result(self):
         analysis = self._make_analysis()
@@ -373,12 +432,12 @@ class TestWireMeasurementAnalysisOtherMethods(TestCase):
             "_fit_data_by_profile",
             return_value=expected_fit_result,
         ) as mock_fit, patch.object(analysis, "_get_rms_sizes", return_value=(1.0, 2.0)) as mock_rms:
-            result = analysis.analyze()
+            result = analysis.analyze(rms_detector="D1")
 
         mock_idx.assert_called_once_with()
         mock_org.assert_called_once_with(expected_indices)
         mock_fit.assert_called_once_with(profile_measurements=expected_profiles)
-        mock_rms.assert_called_once_with(expected_fit_result)
+        mock_rms.assert_called_once_with(expected_fit_result, detector="D1")
         self.assertEqual(set(result.fit_result.keys()), {"x"})
         self.assertEqual(result.fit_result["x"].detectors["D1"].sigma, 1.0)
         np.testing.assert_array_equal(np.asarray(result.rms_sizes), np.array([1.0, 2.0]))

--- a/tests/test_wire_scan_analysis.py
+++ b/tests/test_wire_scan_analysis.py
@@ -9,6 +9,7 @@ from slac_measurements.wires.analysis_results import (
     DetectorProfileMeasurement,
     FitResult,
     ProfileMeasurement,
+    WireMeasurementAnalysisResult,
 )
 from slac_measurements.wires.collection_results import (
     MeasurementMetadata,
@@ -442,3 +443,104 @@ class TestWireMeasurementAnalysisOtherMethods(TestCase):
         self.assertEqual(result.fit_result["x"].detectors["D1"].sigma, 1.0)
         np.testing.assert_array_equal(np.asarray(result.rms_sizes), np.array([1.0, 2.0]))
         self.assertEqual(set(result.profiles.keys()), {"x"})
+
+
+class TestWireMeasurementAnalysisResult(TestCase):
+    @staticmethod
+    def _make_result() -> WireMeasurementAnalysisResult:
+        metadata = MeasurementMetadata(
+            wire_name="WIRE",
+            area="TEST",
+            beampath="TEST",
+            detectors=["D1", "D2"],
+            default_detector="D1",
+            scan_ranges={"x": (0, 1), "y": (0, 1)},
+            timestamp=datetime.now(),
+            active_profiles=["x", "y"],
+            install_angle=45.0,
+        )
+        collection_result = WireMeasurementCollectionResult(
+            raw_data={"WIRE": np.array([0.0, 1.0])},
+            metadata=metadata,
+        )
+        fit_result = {
+            "x": FitResult(
+                detectors={
+                    "D1": DetectorFit(
+                        mean=0.0,
+                        sigma=1.25,
+                        amplitude=10.0,
+                        offset=0.0,
+                        curve=np.array([1.0, 2.0]),
+                        positions=np.array([0.0, 1.0]),
+                    ),
+                    "D2": DetectorFit(
+                        mean=0.0,
+                        sigma=3.5,
+                        amplitude=11.0,
+                        offset=0.0,
+                        curve=np.array([1.0, 2.0]),
+                        positions=np.array([0.0, 1.0]),
+                    ),
+                }
+            ),
+            "y": FitResult(
+                detectors={
+                    "D1": DetectorFit(
+                        mean=0.0,
+                        sigma=2.5,
+                        amplitude=8.0,
+                        offset=0.0,
+                        curve=np.array([1.0, 2.0]),
+                        positions=np.array([0.0, 1.0]),
+                    ),
+                    "D2": DetectorFit(
+                        mean=0.0,
+                        sigma=4.5,
+                        amplitude=9.0,
+                        offset=0.0,
+                        curve=np.array([1.0, 2.0]),
+                        positions=np.array([0.0, 1.0]),
+                    ),
+                }
+            ),
+        }
+
+        return WireMeasurementAnalysisResult(
+            fit_result=fit_result,
+            collection_result=collection_result,
+            profiles={},
+            rms_sizes=np.array([1.25, 2.5]),
+            metadata=metadata,
+        )
+
+    def test_set_rms_detector_updates_rms_sizes_and_metadata(self):
+        result = self._make_result()
+
+        result.set_rms_detector("D2")
+
+        np.testing.assert_array_equal(
+            np.asarray(result.rms_sizes),
+            np.array([3.5, 4.5], dtype=object),
+        )
+        self.assertEqual(result.metadata.rms_detector, "D2")
+        self.assertEqual(result.collection_result.metadata.rms_detector, "D2")
+
+    def test_set_rms_detector_uses_default_when_detector_omitted(self):
+        result = self._make_result()
+        result.metadata.rms_detector = "D2"
+        result.collection_result.metadata.rms_detector = "D2"
+
+        result.set_rms_detector()
+
+        np.testing.assert_array_equal(
+            np.asarray(result.rms_sizes),
+            np.array([1.25, 2.5], dtype=object),
+        )
+        self.assertEqual(result.metadata.rms_detector, "D1")
+
+    def test_set_rms_detector_raises_for_unknown_detector(self):
+        result = self._make_result()
+
+        with self.assertRaises(ValueError):
+            result.set_rms_detector("D3")


### PR DESCRIPTION
## Summary
This PR improves wire-scan analysis by making detector selection for RMS extraction configurable while preserving default behavior.

The analysis still defaults to the newly configured metadata default detector, but users now have direct control to choose a different detector when desired.

## What Changed
- Added an optional rms_detector input to measurement and analysis entry points.
- Updated RMS extraction logic to:
  - use metadata.default_detector when no override is provided
  - use the requested detector when rms_detector is provided
  - raise a clear ValueError when an unavailable detector is requested
- Added rms_detector to measurement metadata for persistence and visibility.
- Added result-level detector switching through set_rms_detector(detector=None), allowing users to toggle detector choice without recollecting data.
- Updated result string output to include rms_detector so the selected detector is clearly shown to the user.
- Kept default behavior aligned with the configured metadata default detector, with fallback handling when needed.

## Why This Is Better
- Easier detector toggling: users can switch which detector drives RMS sizes with a simple override.
- Better user awareness: outputs now clearly indicate which detector was used.
- Preserved defaults: existing workflows continue to use the configured default detector automatically.
- More control: users can intentionally choose another detector when analysis needs differ.

## Backward Compatibility
- Existing behavior is preserved when rms_detector is not provided.
- The configured metadata default detector remains the default source for RMS extraction.
- New behavior is opt-in and non-breaking.

## Test Coverage
- Verified rms_detector override is passed through measurement and analysis flows.
- Verified RMS sizes are computed from the selected detector when overridden.
- Verified invalid detector requests raise ValueError.
- Verified set_rms_detector updates both RMS values and metadata.
- Verified omitting detector in set_rms_detector reverts to metadata default behavior.

## Example Usage
- Default behavior: run analysis using metadata.default_detector.
- Override behavior: pass rms_detector to analyze using a specific detector.
- Post-analysis toggle: call set_rms_detector to switch detector and recompute RMS from existing fit results.