### PR TITLE
Refactor wire initialization logic to improve readiness checks and lo…

### DIFF
--- a/slac_measurements/wires/collection.py
+++ b/slac_measurements/wires/collection.py
@@ -60,23 +60,23 @@ class WireMeasurementCollection(slac_measurements.beam_profile.BeamProfileMeasur
     def my_wire(self, value):
         self.beam_profile_device = value
 
-    def measure(self, scan_type: str = "step") -> WireMeasurementCollectionResult:
+    def measure(self, scan_mode: str = "step") -> WireMeasurementCollectionResult:
         """
         Execute wire scan: move wire, acquire detector data from BSA buffer.
 
         Two scan modes are supported:
-        - ``on_the_fly`` : use the wire's built-in start_scan command and
-          collect data while the wire moves continuously.
-        - ``step`` : perform a discrete (step) scan by moving the motor to each
-          inner/outer position in sequence with the buffer acquiring the whole
-          time.
+            - ``otf`` : On-the-fly scan using the wire's built-in start_scan command and
+              collect data while the wire moves continuously.
+            - ``step`` : perform a discrete (step) scan by moving the motor to each
+              inner/outer position in sequence with the buffer acquiring the whole
+              time.
 
-        The desired mode can be selected by passing ``scan_type``.
+        The desired mode can be selected by passing ``scan_mode``.
 
         Parameters
         ----------
-        scan_type : str, optional
-            ``"on_the_fly"`` or ``"step"``.  Any other value will raise a
+        scan_mode : str, optional
+            ``"otf"`` or ``"step"``. Any other value will raise a
             ``ValueError``.
 
         Returns
@@ -86,18 +86,18 @@ class WireMeasurementCollection(slac_measurements.beam_profile.BeamProfileMeasur
             - raw_data: Buffered position and detector values by device name
             - metadata: Timestamp, wire name, area, beampath, and detector list
         """
-        if scan_type not in ("on_the_fly", "step"):
+        if scan_mode not in ("otf", "step"):
             raise ValueError(
-                f"Unknown scan_type '{scan_type}'. ``on_the_fly`` or ``step`` expected."
+                f"Unknown scan_mode '{scan_mode}'. ``otf`` or ``step`` expected."
             )
 
         self.my_buffer = self._reserve_buffer()
         metadata = self._create_metadata()
-        self._scan_with_wire(scan_type=scan_type)
+        self._scan_with_wire(scan_mode=scan_mode)
 
         # For on‑the‑fly scans we must start the timing buffer here; the step
         # implementation already handles the buffer start and wait internally.
-        if scan_type == "on_the_fly":
+        if scan_mode == "otf":
             self._start_timing_buffer()
 
         # Get position and detector data from the buffer
@@ -294,41 +294,35 @@ class WireMeasurementCollection(slac_measurements.beam_profile.BeamProfileMeasur
         self.logger.info("Data retrieved from buffer. Scan complete.")
         return data
 
-    def _initialize_wire_with_retry(self, wire_action: str, max_attempts: int = 3) -> None:
-        """Call start_scan/initialize with retries until wire is ready.
+    def _initialize_wire_with_retry(self, scan_mode: str, max_attempts: int = 3) -> None:
+        """Initialize wire motion with retries until wire is ready for scan mode.
 
         Readiness conditions:
-        - start_scan: wait for both my_wire.homed and my_wire.on_status.
-        - initialize: wait for my_wire.enabled.
+        - otf: wait for both my_wire.homed and my_wire.on_status.
+        - step: wait for my_wire.enabled.
 
-        wire_action must be 'start_scan' or 'initialize'; raises on failure.
+        scan_mode must be 'otf' or 'step'; raises on failure.
         """
-        if wire_action not in ("start_scan", "initialize"):
+        if scan_mode not in ("otf", "step"):
             raise ValueError(
-                f"Unknown wire_action '{wire_action}'. Expected 'start_scan' or 'initialize'."
+                f"Unknown scan_mode '{scan_mode}'. Expected 'otf' or 'step'."
             )
 
-        if wire_action == "start_scan":
+        if scan_mode == "otf":
+            action_method = self.my_wire.start_scan
             ready_check = lambda: self.my_wire.homed and self.my_wire.on_status
             ready_desc = "homed and on"
+            action_desc = "for on-the-fly scan"
         else:
+            action_method = self.my_wire.initialize
             ready_check = lambda: self.my_wire.enabled
             ready_desc = "enabled"
+            action_desc = "for step scan"
 
         # Skip initialization if wire is already in the expected ready state
         if ready_check():
             self.logger.info(f"{self.my_wire.name} is already {ready_desc}.")
             return
-
-        # Choose the appropriate method to call
-        action_method = (
-            self.my_wire.start_scan
-            if wire_action == "start_scan"
-            else self.my_wire.initialize
-        )
-        action_desc = (
-            "for on-the-fly scan" if wire_action == "start_scan" else "for step scan"
-        )
 
         for attempt in range(1, max_attempts + 1):
             self.logger.info(
@@ -406,7 +400,7 @@ class WireMeasurementCollection(slac_measurements.beam_profile.BeamProfileMeasur
         self.logger.info("Performing step scan mode")
 
         # Initialize wire for step scan (with retry logic, no continuous motion)
-        self._initialize_wire_with_retry(wire_action="initialize")
+        self._initialize_wire_with_retry(scan_mode="step")
 
         # Start buffer acquisition after successful wire initialization
         self.logger.info("Starting buffer acquisition for step scan...")
@@ -438,11 +432,11 @@ class WireMeasurementCollection(slac_measurements.beam_profile.BeamProfileMeasur
 
         return self.my_buffer
 
-    def _scan_with_wire(self, scan_type: str = "step") -> None:
+    def _scan_with_wire(self, scan_mode: str = "step") -> None:
         """
         Kick off motion for the wire and (optionally) the buffer.
 
-        The behaviour depends on the requested ``scan_type``.  The default is
+        The behaviour depends on the requested ``scan_mode``.  The default is
         ``step`` which drives the wire to each of the inner/outer positions one
         at a time while the buffer is already running.  The latter is useful for
         setups where the wire cannot use the
@@ -450,19 +444,18 @@ class WireMeasurementCollection(slac_measurements.beam_profile.BeamProfileMeasur
 
         Parameters
         ----------
-        scan_type : str, optional
-            ``"on_the_fly"`` or ``"step"``.  ``step`` behaviour is the
-            historic default.
+        scan_mode : str, optional
+            ``"otf"`` or ``"step"``.
         """
         # Reserve a new buffer if necessary
         self.my_buffer = self._reserve_buffer()
 
-        if scan_type == "on_the_fly":
-            self._initialize_wire_with_retry(wire_action="start_scan")
-        elif scan_type == "step":
+        if scan_mode == "otf":
+            self._initialize_wire_with_retry(scan_mode="otf")
+        elif scan_mode == "step":
             self._perform_step_scan()
         else:
-            raise ValueError(f"Unsupported scan_type '{scan_type}'")
+            raise ValueError(f"Unsupported scan_mode '{scan_mode}'")
 
     def _start_timing_buffer(self) -> None:
         """

--- a/slac_measurements/wires/collection.py
+++ b/slac_measurements/wires/collection.py
@@ -295,7 +295,11 @@ class WireMeasurementCollection(slac_measurements.beam_profile.BeamProfileMeasur
         return data
 
     def _initialize_wire_with_retry(self, wire_action: str, max_attempts: int = 3) -> None:
-        """Call start_scan/initialize with retries until wire.enabled.
+        """Call start_scan/initialize with retries until wire is ready.
+
+        Readiness conditions:
+        - start_scan: wait for both my_wire.homed and my_wire.on_status.
+        - initialize: wait for my_wire.enabled.
 
         wire_action must be 'start_scan' or 'initialize'; raises on failure.
         """
@@ -304,9 +308,16 @@ class WireMeasurementCollection(slac_measurements.beam_profile.BeamProfileMeasur
                 f"Unknown wire_action '{wire_action}'. Expected 'start_scan' or 'initialize'."
             )
 
-        # Skip initialization if wire is already enabled
-        if self.my_wire.enabled:
-            self.logger.info(f"{self.my_wire.name} is already enabled.")
+        if wire_action == "start_scan":
+            ready_check = lambda: self.my_wire.homed and self.my_wire.on_status
+            ready_desc = "homed and on"
+        else:
+            ready_check = lambda: self.my_wire.enabled
+            ready_desc = "enabled"
+
+        # Skip initialization if wire is already in the expected ready state
+        if ready_check():
+            self.logger.info(f"{self.my_wire.name} is already {ready_desc}.")
             return
 
         # Choose the appropriate method to call
@@ -327,8 +338,10 @@ class WireMeasurementCollection(slac_measurements.beam_profile.BeamProfileMeasur
             action_method()
 
             # If returns True within timeout, proceed
-            if slac_measurements.utils.wait_until(lambda: self.my_wire.enabled):
-                self.logger.info(f"{self.my_wire.name} initialized.")
+            if slac_measurements.utils.wait_until(ready_check):
+                self.logger.info(
+                    "%s initialized (%s is True).", self.my_wire.name, ready_desc
+                )
                 return
 
             # After timeout, log and iterate through for loop again

--- a/slac_measurements/wires/scan.py
+++ b/slac_measurements/wires/scan.py
@@ -31,7 +31,7 @@ class WireBeamProfileMeasurement(
 
     def measure(
         self,
-        scan_type: str = "step",
+        scan_mode: str = "step",
         fitting_method: Literal[
             "gaussian", "asymmetric_gaussian", "super_gaussian"
         ] = "gaussian",
@@ -42,8 +42,8 @@ class WireBeamProfileMeasurement(
 
         Parameters
         ----------
-        scan_type : str
-            ``"on_the_fly"`` or ``"step"`` (default).
+        scan_mode : str
+            ``"otf"`` or ``"step"`` (default).
         fitting_method : str, optional
             Fit model used by the downstream wire-scan analysis. Supported
             values are ``"gaussian"``, ``"asymmetric_gaussian"``, and
@@ -58,7 +58,7 @@ class WireBeamProfileMeasurement(
             beam_profile_device=self.beam_profile_device,
             beampath=self.beampath,
         )
-        self.collection_result = collection.measure(scan_type=scan_type)
+        self.collection_result = collection.measure(scan_mode=scan_mode)
         return self.analyze(fitting_method=fitting_method)
 
     def analyze(self, fitting_method) -> WireMeasurementAnalysisResult:

--- a/tests/test_wire_scan.py
+++ b/tests/test_wire_scan.py
@@ -61,7 +61,7 @@ class WireBeamProfileMeasurementTest(TestCase):
             beam_profile_device=measurement.beam_profile_device,
             beampath="TEST",
         )
-        mock_collection.measure.assert_called_once_with(scan_type="step")
+        mock_collection.measure.assert_called_once_with(scan_mode="step")
         mock_analysis_cls.assert_called_once_with(
             collection_result="collection-result",
             fitting_method="super_gaussian",
@@ -88,7 +88,7 @@ class WireBeamProfileMeasurementTest(TestCase):
         result = measurement.measure(fitting_method="asymmetric_gaussian")
 
         self.assertEqual(result, "analysis-result")
-        mock_collection.measure.assert_called_once_with(scan_type="step")
+        mock_collection.measure.assert_called_once_with(scan_mode="step")
         mock_analysis_cls.assert_called_once_with(
             collection_result="collection-result",
             fitting_method="asymmetric_gaussian",


### PR DESCRIPTION
This pull request refines the wire initialization logic in `slac_measurements/wires/collection.py` to better handle different readiness conditions for the `start_scan` and `initialize` actions. The changes improve clarity and correctness by distinguishing the wire's readiness states and generalizing the checks and logging accordingly.

Improvements to wire readiness checks and initialization:

* Updated the docstring for `_initialize_wire_with_retry` to clarify that readiness conditions differ for `start_scan` (requires both `my_wire.homed` and `my_wire.on_status`) and `initialize` (requires `my_wire.enabled`).
* Refactored the readiness checking logic to use a lambda (`ready_check`) and description (`ready_desc`) depending on the action, allowing the method to skip initialization if the wire is already in the appropriate ready state.
* Updated the post-action readiness check and logging to use the new generalized readiness logic, improving both accuracy and clarity of log messages.