### PR TITLE
Retraction logic fix and Analysis results fix

### DIFF
--- a/slac_measurements/wires/analysis_results.py
+++ b/slac_measurements/wires/analysis_results.py
@@ -145,6 +145,13 @@ class WireMeasurementAnalysisResult(BeamProfileMeasurementResult):
         import h5py
 
         with h5py.File(filepath, "w") as f:
+            def _to_h5_float_array(values) -> np.ndarray:
+                """Convert optional numeric-like values to float array for HDF5."""
+                return np.array(
+                    [np.nan if value is None else float(value) for value in values],
+                    dtype=float,
+                )
+
             # store the collection result under its own subgroup so that
             # standalone collection loaders can still operate if needed
             col_grp = f.create_group("collection_result")
@@ -163,7 +170,10 @@ class WireMeasurementAnalysisResult(BeamProfileMeasurementResult):
             # save the beam profile measurement fields inherited from
             # BeamProfileMeasurementResult
             if self.rms_sizes is not None:
-                f.create_dataset("rms_sizes", data=np.array(self.rms_sizes))
+                f.create_dataset(
+                    "rms_sizes",
+                    data=_to_h5_float_array(self.rms_sizes),
+                )
             if self.centroids is not None:
                 f.create_dataset("centroids", data=np.array(self.centroids))
             if self.total_intensities is not None:
@@ -232,7 +242,11 @@ def load_from_h5(filepath: str) -> WireMeasurementAnalysisResult:
 
         # beam profile fields
         rms = f.get("rms_sizes")
-        rms_val = tuple(rms[:]) if rms is not None else None
+        rms_val = (
+            tuple(None if np.isnan(v) else float(v) for v in rms[:])
+            if rms is not None
+            else None
+        )
         centroids = f.get("centroids")
         cent_val = centroids[:] if centroids is not None else None
         totint = f.get("total_intensities")

--- a/slac_measurements/wires/collection.py
+++ b/slac_measurements/wires/collection.py
@@ -20,6 +20,7 @@ _DATE = datetime.now().strftime("%Y%m%d")
 _LOG_FILENAME = f"ws_log_{_DATE}.txt"
 _LOGGER_NAME = "wire_scan_logger"
 _WIRE_TOLERANCE = 250  # microns
+_WIRE_RETRACT_WAIT = 2 # seconds
 
 
 class WireMeasurementCollection(slac_measurements.beam_profile.BeamProfileMeasurement):
@@ -397,7 +398,10 @@ class WireMeasurementCollection(slac_measurements.beam_profile.BeamProfileMeasur
         # Retract wire
         self.logger.info("Retracting wire...")
         self.my_wire.speed = int(self.my_wire.speed_max)
-        self.my_wire.motor = 100
+        time.sleep(_WIRE_RETRACT_WAIT)  # Ensure speed change takes effect before retracting
+        self.my_wire.retract()
+        retract_posn = self.my_wire.motor_rbv
+        self.logger.info(f"Wire retraction command issued. Motor position: {retract_posn}")
 
         # Wait for buffer acquisition to complete
         self.logger.info("Waiting for buffer acquisition to complete...")

--- a/tests/test_wire_scan_analysis.py
+++ b/tests/test_wire_scan_analysis.py
@@ -479,4 +479,4 @@ class TestWireMeasurementAnalysisResult(TestCase):
             self.result.save_to_h5(outpath)
             loaded = load_from_h5(outpath)
 
-        self.assertEqual(loaded.rms_sizes, (1.25, None))
+        self.assertEqual(tuple(loaded.rms_sizes), (1.25, None))

--- a/tests/test_wire_scan_analysis.py
+++ b/tests/test_wire_scan_analysis.py
@@ -1,5 +1,6 @@
 import numpy as np
 from datetime import datetime
+from tempfile import TemporaryDirectory
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -10,6 +11,7 @@ from slac_measurements.wires.analysis_results import (
     FitResult,
     ProfileMeasurement,
     WireMeasurementAnalysisResult,
+    load_from_h5,
 )
 from slac_measurements.wires.collection_results import (
     MeasurementMetadata,
@@ -468,3 +470,13 @@ class TestWireMeasurementAnalysisResult(TestCase):
     def test_set_rms_detector_raises_for_unknown_detector(self):
         with self.assertRaises(ValueError):
             self.result.set_rms_detector("D3")
+
+    def test_save_to_h5_handles_object_rms_sizes(self):
+        self.result.rms_sizes = np.array([1.25, None], dtype=object)
+
+        with TemporaryDirectory() as tmpdir:
+            outpath = f"{tmpdir}/analysis_result.h5"
+            self.result.save_to_h5(outpath)
+            loaded = load_from_h5(outpath)
+
+        self.assertEqual(loaded.rms_sizes, (1.25, None))


### PR DESCRIPTION
Two small changes plus updated tests.

1. Step scan wire retraction fix.  The command to retract was first, insufficient, and second, being sent out of sync.  Added a two second wait (confirmed experimentally in ACR this morning) and a printout of the position after the retract command is sent.
2. When saving datasets that do not have all 3 profiles, an error would get thrown. I've added a small check that skips saving that profile's rms value if it doesn't exist, e.g., we only scanned the X profile.