### PR TITLE
Optics refactor and minor changes for emittance measurement

### DIFF
--- a/slac_measurements/emittance_measurement.py
+++ b/slac_measurements/emittance_measurement.py
@@ -23,7 +23,7 @@ from slac_measurements.model_general_calcs import (
     build_quad_rmat,
     bdes_to_kmod,
     multi_device_optics,
-    get_rmat_after_magnet,
+    get_optics_after_magnet,
     quad_scan_optics,
 )
 import slac_measurements
@@ -225,7 +225,7 @@ class EmittanceMeasurementBase(Measurement):
     """
 
     energy: float
-    physics_model: Literal["BMAD", "BLEM", "Lucretia"] = "BLEM"
+    physics_model: Literal["BMAD", "BLEM", "Lucretia"] = "BMAD"
 
     wait_time: PositiveFloat = 5.0
 
@@ -411,12 +411,14 @@ class QuadScanEmittance(Measurement):
         """
 
         if self.manual_quad_rmats:
-            drift_rmat = get_rmat_after_magnet(
+            optics = get_optics_after_magnet(
                 self.magnet,
-                self.beamsize_measurement,
+                self.beamsize_measurement.beam_profile_device,
                 self.physics_model,
             )
-            self.rmat = np.stack([drift_rmat[0:2, 0:2], drift_rmat[2:4, 2:4]])
+            after_quad_rmat = optics["after_quad_rmat"]
+            self.rmat = np.stack([after_quad_rmat[0:2, 0:2], after_quad_rmat[2:4, 2:4]])
+            self.design_twiss = optics["design_twiss"]
 
         if self.rmat is None or self.rmat.size == 0:
             self.rmat_given = False
@@ -564,7 +566,7 @@ class QuadScanEmittance(Measurement):
         if not self.rmat_given:
             optics = quad_scan_optics(
                 self.magnet,
-                self.beamsize_measurement,
+                self.beamsize_measurement.beam_profile_device,
                 self.physics_model,
             )
             rmat = optics["rmat"]
@@ -619,12 +621,14 @@ class MultiDeviceEmittance(EmittanceMeasurementBase):
         object attributes
 
         """
+        beam_profile_devices = []
         beam_profiles = []
         for beamsize_measurement in self.beamsize_measurements:
+            beam_profile_devices.append(beamsize_measurement.beam_profile_device)
             beam_profiles.append(beamsize_measurement.measure())
 
         optics = multi_device_optics(
-            self.beamsize_measurements,
+            beam_profile_devices,
             self.physics_model,
         )
 

--- a/slac_measurements/emittance_measurement.py
+++ b/slac_measurements/emittance_measurement.py
@@ -89,6 +89,39 @@ class EmittanceMeasurementResult(slac_measurements.BaseModel):
     beam_matrix: NDArrayAnnotatedType
     metadata: SerializeAsAny[Any]
 
+class MultiDeviceEmittanceResult(EmittanceMeasurementResult):
+    """
+    EmittanceMeasurementResult stores the results of an emittance measurement.
+
+    Attributes
+    ----------
+    beam_profile_devices_names: List[str]
+        Names of beam profile devices used for measurement
+    beam_profile_devices_z: List[float]
+        z locations of beam profile devices
+
+    Inherited Attributes
+    ----------
+    emittance : shape (2,)
+        The geometric emittance values for x/y in mm-mrad.
+    bmag : List[ndarray], Optional
+        The BMAG values for x/y for each quadrupole strength.
+    twiss : List[ndarray]
+        Twiss parameters (beta, alpha, gamma) calculated at the beam profile device
+        for each quadrupole strength in each plane.
+    rms_beamsizes : List[ndarray]
+        The RMS beam sizes for each quadrupole strength in each plane in meters.
+    beam_matrix : array, shape (2,3)
+        Reconstructed beam matrix at the entrance of the quadrupole for
+        both x/y directions. Elements correspond to (s11,s12,s22) of the beam matrix.
+    info : Any
+        Metadata information related to the measurement.
+
+    """
+
+    beam_profile_devices_names: List[str]
+    beam_profile_devices_z: List[float]
+
 
 class QuadScanEmittanceResult(EmittanceMeasurementResult):
     """
@@ -225,7 +258,7 @@ class EmittanceMeasurementBase(Measurement):
     """
 
     energy: float
-    physics_model: Literal["BMAD", "BLEM", "Lucretia"] = "BMAD"
+    physics_model: Literal["BMAD", "BLEM", "Lucretia"] = "BLEM"
 
     wait_time: PositiveFloat = 5.0
 
@@ -385,7 +418,7 @@ class QuadScanEmittance(Measurement):
 
     rmat: Optional[ndarray] = None
     design_twiss: Optional[dict] = None  # design twiss values
-    physics_model: Literal["BMAD", "BLEM", "Lucretia"] = "BMAD"
+    physics_model: Literal["BMAD", "BLEM", "Lucretia"] = "BLEM"
 
     wait_time: PositiveFloat = 1.0
 
@@ -648,13 +681,17 @@ class MultiDeviceEmittance(EmittanceMeasurementBase):
             Object containing the results of the emittance measurement
 
         """
+        beam_profile_devices_names = [measurement.beam_profile_device.name for measurement in self.beamsize_measurements]
+        beam_profile_devices_z = [measurement.beam_profile_device.metadata.sum_l_meters for measurement in self.beamsize_measurements]
         metadata = self.model_dump()
         results_dict = emittance_dict | {
+            "beam_profile_devices_names": beam_profile_devices_names,
+            "beam_profile_devices_z": beam_profile_devices_z,
             "rms_beamsizes": beam_sizes,
             "metadata": metadata,
         }
 
-        return EmittanceMeasurementResult(**results_dict)
+        return MultiDeviceEmittanceResult(**results_dict)
 
 
 def compute_emit_bmag_quad_scan(

--- a/slac_measurements/emittance_measurement.py
+++ b/slac_measurements/emittance_measurement.py
@@ -89,39 +89,6 @@ class EmittanceMeasurementResult(slac_measurements.BaseModel):
     beam_matrix: NDArrayAnnotatedType
     metadata: SerializeAsAny[Any]
 
-class MultiDeviceEmittanceResult(EmittanceMeasurementResult):
-    """
-    EmittanceMeasurementResult stores the results of an emittance measurement.
-
-    Attributes
-    ----------
-    beam_profile_devices_names: List[str]
-        Names of beam profile devices used for measurement
-    beam_profile_devices_z: List[float]
-        z locations of beam profile devices
-
-    Inherited Attributes
-    ----------
-    emittance : shape (2,)
-        The geometric emittance values for x/y in mm-mrad.
-    bmag : List[ndarray], Optional
-        The BMAG values for x/y for each quadrupole strength.
-    twiss : List[ndarray]
-        Twiss parameters (beta, alpha, gamma) calculated at the beam profile device
-        for each quadrupole strength in each plane.
-    rms_beamsizes : List[ndarray]
-        The RMS beam sizes for each quadrupole strength in each plane in meters.
-    beam_matrix : array, shape (2,3)
-        Reconstructed beam matrix at the entrance of the quadrupole for
-        both x/y directions. Elements correspond to (s11,s12,s22) of the beam matrix.
-    info : Any
-        Metadata information related to the measurement.
-
-    """
-
-    beam_profile_devices_names: List[str]
-    beam_profile_devices_z: List[float]
-
 
 class QuadScanEmittanceResult(EmittanceMeasurementResult):
     """
@@ -258,7 +225,7 @@ class EmittanceMeasurementBase(Measurement):
     """
 
     energy: float
-    physics_model: Literal["BMAD", "BLEM", "Lucretia"] = "BLEM"
+    physics_model: Literal["BMAD", "BLEM", "Lucretia"] = "BMAD"
 
     wait_time: PositiveFloat = 5.0
 
@@ -418,7 +385,7 @@ class QuadScanEmittance(Measurement):
 
     rmat: Optional[ndarray] = None
     design_twiss: Optional[dict] = None  # design twiss values
-    physics_model: Literal["BMAD", "BLEM", "Lucretia"] = "BLEM"
+    physics_model: Literal["BMAD", "BLEM", "Lucretia"] = "BMAD"
 
     wait_time: PositiveFloat = 1.0
 
@@ -681,17 +648,13 @@ class MultiDeviceEmittance(EmittanceMeasurementBase):
             Object containing the results of the emittance measurement
 
         """
-        beam_profile_devices_names = [measurement.beam_profile_device.name for measurement in self.beamsize_measurements]
-        beam_profile_devices_z = [measurement.beam_profile_device.metadata.sum_l_meters for measurement in self.beamsize_measurements]
         metadata = self.model_dump()
         results_dict = emittance_dict | {
-            "beam_profile_devices_names": beam_profile_devices_names,
-            "beam_profile_devices_z": beam_profile_devices_z,
             "rms_beamsizes": beam_sizes,
             "metadata": metadata,
         }
 
-        return MultiDeviceEmittanceResult(**results_dict)
+        return EmittanceMeasurementResult(**results_dict)
 
 
 def compute_emit_bmag_quad_scan(

--- a/slac_measurements/model_general_calcs.py
+++ b/slac_measurements/model_general_calcs.py
@@ -1,9 +1,11 @@
-from typing import Dict
+from typing import Dict, Union
 
 import numpy as np
 
 from slac_devices.magnet import Magnet
 
+from slac_devices.screen import Screen
+from slac_devices.wire import Wire
 from slac_measurements.beam_profile import BeamProfileMeasurement
 
 
@@ -61,58 +63,62 @@ def bdes_to_kmod(e_tot=None, effective_length=None, bdes=None, tao=None, element
 
 
 def quad_scan_optics(
-    magnet: Magnet, measurement: BeamProfileMeasurement, physics_model="BLEM"
+    magnet: Magnet, beam_profile_device: Union[Screen, Wire], physics_model="BMAD"
 ) -> Dict:
     """Get rmat (6 x 6) from magnet to measurement device and twiss at measurement device"""
     # TODO: get optics from arbitrary devices (potentially in different beam lines)
     # have live BLEM model update
     if physics_model == "BLEM":
         refresh_blem_model()
-    model = _get_model_from_device(measurement.beam_profile_device, physics_model)
-    rmat = model.get_rmat(
+    model_live = _get_model_from_device(beam_profile_device, physics_model, use_design=False)
+    rmat = model_live.get_rmat(
         from_device=magnet.name,
-        to_device=measurement.beam_profile_device.name,
+        to_device=beam_profile_device.name,
     )
-    twiss = model.get_twiss(measurement.beam_profile_device.name)
+    model_design = _get_model_from_device(beam_profile_device, physics_model, use_design=True)
+    twiss = model_design.get_twiss(beam_profile_device.name)
     return {"rmat": rmat, "design_twiss": twiss}
 
 
-def get_rmat_after_magnet(
-    magnet: Magnet, measurement: BeamProfileMeasurement, physics_model="BLEM"
-) -> np.ndarray:
+def get_optics_after_magnet(
+    magnet: Magnet, beam_profile_device: Union[Screen, Wire], physics_model="BMAD"
+) -> Dict:
     """Get rmat from end of magnet to measurement device"""
     # have live BLEM model update
     if physics_model == "BLEM":
         refresh_blem_model()
-    model = _get_model_from_device(measurement.beam_profile_device, physics_model)
-    full_rmat = model.get_rmat(
+    model_live = _get_model_from_device(beam_profile_device, physics_model, use_design=False)
+    full_rmat = model_live.get_rmat(
         from_device=magnet.name,
-        to_device=measurement.beam_profile_device.name,
+        to_device=beam_profile_device.name,
     )
-    quad_rmat = model.get_rmat(
+    quad_rmat = model_live.get_rmat(
         from_device=magnet.name,
         to_device=magnet.name,
     )
-    drift_rmat = full_rmat @ np.linalg.inv(quad_rmat)
-    return drift_rmat
+    after_quad_rmat = full_rmat @ np.linalg.inv(quad_rmat)
+    model_design = _get_model_from_device(beam_profile_device, physics_model, use_design=False)
+    twiss = model_design.get_twiss(beam_profile_device.name)
+    return {"after_quad_rmat": after_quad_rmat, "design_twiss": twiss}
 
 
 def multi_device_optics(
-    measurements: list[BeamProfileMeasurement], physics_model="BLEM"
+    beam_profile_devices: list[Union[Screen, Wire]], physics_model="BMAD"
 ) -> Dict:
     """Get rmat and twiss from reference device to all measurement devices"""
-    model = _get_model_from_device(measurements[-1].beam_profile_device, physics_model)
+    model_live = _get_model_from_device(beam_profile_devices[-1], physics_model, use_design=False)
     beam_profile_device_names = [
-        measurement.beam_profile_device.name for measurement in measurements
+        beam_profile_device.name for beam_profile_device in beam_profile_devices
     ]
     rmat = []
     ref_index = int(len(beam_profile_device_names) / 2)
     device_ref = beam_profile_device_names[ref_index]
     for device in beam_profile_device_names:
-        rmat.append(model.get_rmat(device_ref, device))
+        rmat.append(model_live.get_rmat(device_ref, device))
     rmat = np.array(rmat)
-    twiss = model.get_twiss(beam_profile_device_names)
-    return {"rmat": rmat, "lattice_twiss": twiss}
+    model_design = _get_model_from_device(beam_profile_devices[-1], physics_model, use_design=True)
+    twiss = model_design.get_twiss(beam_profile_device_names)
+    return {"rmat": rmat, "design_twiss": twiss}
 
 
 def refresh_blem_model():
@@ -132,7 +138,7 @@ def refresh_blem_model():
     done.wait()  # blocks until ctrl PV has reset to 0
 
 
-def _get_model_from_device(device, physics_model):
+def _get_model_from_device(device, physics_model, use_design=False):
     from meme.model import Model
 
     # Look for device beam path in meme beam paths
@@ -153,7 +159,7 @@ def _get_model_from_device(device, physics_model):
     if beam_path is None:
         raise ValueError("Valid beam path not found in device metadata.")
 
-    return Model(beam_path, model_source=physics_model, use_design=False)
+    return Model(beam_path, model_source=physics_model, use_design=use_design)
 
 
 def propagate_twiss(twiss_init: np.ndarray, rmat: np.ndarray):

--- a/slac_measurements/model_general_calcs.py
+++ b/slac_measurements/model_general_calcs.py
@@ -97,7 +97,7 @@ def get_optics_after_magnet(
         to_device=magnet.name,
     )
     after_quad_rmat = full_rmat @ np.linalg.inv(quad_rmat)
-    model_design = _get_model_from_device(beam_profile_device, physics_model, use_design=False)
+    model_design = _get_model_from_device(beam_profile_device, physics_model, use_design=True)
     twiss = model_design.get_twiss(beam_profile_device.name)
     return {"after_quad_rmat": after_quad_rmat, "design_twiss": twiss}
 


### PR DESCRIPTION
This PR introduces various refactoring and minor functionality changes related to the optics for emittance measurements.

- get_rmat_after_magnet changed to get_optics_after_magnet to reflect getting design twiss as well as rmat from right after quad to screen/wire
- optics functions take beam profile devices instead of beamsize measurements as arguments
- optics functions use the live model to get rmats and the design model to get design twiss parameters