### PR TITLE
Add MultiDeviceEmittanceResult and other EmittanceMeasurementResult attributes

### DIFF
--- a/slac_measurements/emittance.py
+++ b/slac_measurements/emittance.py
@@ -54,6 +54,9 @@ def compute_emit_bmag(
         - 'beam_matrix': numpy.ndarray of shape (batchshape x 3) containing [sig11, sig12, sig22]
           where sig11, sig12, sig22 are the reconstructed beam matrix parameters at the entrance
           of the measurement quad.
+        - 'twiss_at_reconstruction': numpy.ndarray of shape (batchshape x nsteps x 3) containing the
+          reconstructed twiss parameters at the reference point (e.g. right before the quad in a quad 
+          scan or at the reference beam profile device in a multi measurement).
         - 'twiss': numpy.ndarray of shape (batchshape x nsteps x 3) containing the
           reconstructed twiss parameters at each measurement point (e.g. at the beam profile
           device at each point in a quad scan or at each beam profile device in a multi measurement).
@@ -170,8 +173,8 @@ def compute_emit_bmag(
     )
     # result shape (batchshape x 1)
 
-    # get twiss at upstream origin from beam_matrix
-    def _twiss_upstream(b_matrix):
+    # get twiss from beam_matrix
+    def _twiss_from_beam_matrix(b_matrix):
         return np.expand_dims(
             np.stack(
                 (
@@ -185,8 +188,11 @@ def compute_emit_bmag(
             axis=-2,
         )
 
+    # get twiss params from beam matrix
+    rv["twiss_at_reconstruction"] = _twiss_from_beam_matrix(rv["beam_matrix"])
+    
     # propagate twiss params to beam profile device (expand_dims for broadcasting)
-    rv["twiss"] = propagate_twiss(_twiss_upstream(rv["beam_matrix"]), rmat)
+    rv["twiss"] = propagate_twiss(_twiss_from_beam_matrix(rv["beam_matrix"]), rmat)
     # result shape (batchshape x nsteps x 3)
     beta, alpha = (
         rv["twiss"][..., 0],

--- a/slac_measurements/emittance_measurement.py
+++ b/slac_measurements/emittance_measurement.py
@@ -16,6 +16,7 @@ from pydantic import (
 from slac_devices.magnet import Magnet
 from slac_measurements.emittance import compute_emit_bmag, normalize_emittance
 from slac_measurements.measurement import Measurement
+from slac_measurements.screen_profile import ScreenBeamProfileMeasurement
 from slac_measurements.utils import (
     NDArrayAnnotatedType,
 )
@@ -85,6 +86,7 @@ class EmittanceMeasurementResult(slac_measurements.BaseModel):
     emittance: NDArrayAnnotatedType
     bmag: Optional[NDArrayAnnotatedType] = None
     twiss: NDArrayAnnotatedType
+    rmats: Optional[NDArrayAnnotatedType] = None
     rms_beamsizes: NDArrayAnnotatedType
     beam_matrix: NDArrayAnnotatedType
     metadata: SerializeAsAny[Any]
@@ -287,7 +289,7 @@ class EmittanceMeasurementBase(Measurement):
             beam_profiles, rmats, design_twiss, self.energy
         )
 
-        return self.construct_result(emittance_dict, beam_sizes)
+        return self.construct_result(emittance_dict, beam_sizes, rmats)
 
     @abstractmethod
     def retrieve_beam_profiles_and_optics(self):
@@ -417,6 +419,7 @@ class QuadScanEmittance(Measurement):
     _info: Optional[list] = []
 
     rmat: Optional[ndarray] = None
+    raw_rmats: Optional[NDArrayAnnotatedType] = None
     design_twiss: Optional[dict] = None  # design twiss values
     physics_model: Literal["BMAD", "BLEM", "Lucretia"] = "BLEM"
 
@@ -537,6 +540,7 @@ class QuadScanEmittance(Measurement):
 
                 # compute emittance and bmag
                 result = compute_emit_bmag(**emit_kwargs)
+                result["emittance"] = normalize_emittance(result["emittance"], self.energy)
 
                 result.update({"quadrupole_focusing_strengths": kmod_list[i]})
                 result.update({"quadrupole_pv_values": scan_values[i][idx]})
@@ -562,18 +566,17 @@ class QuadScanEmittance(Measurement):
             }
             # Call wrapper that takes quads in machine units and beamsize in meters
             results = compute_emit_bmag_quad_scan_machine_units(**inputs)
-        results.update(
-            {
-                "metadata": self.model_dump()
-                | {
-                    "resolution": self.beamsize_measurement.beam_profile_device.resolution,
-                    "image_data": {
-                        str(sval): ele.model_dump()
-                        for sval, ele in zip(self.scan_values, self._info)
-                    },
-                }
+        
+        metadata = self.model_dump()
+        if isinstance(self.beamsize_measurement, ScreenBeamProfileMeasurement):
+            metadata["resolution"] = self.beamsize_measurement.beam_profile_device.resolution
+            metadata["image_data"] = {
+                str(sval): ele.model_dump()
+                for sval, ele in zip(self.scan_values, self._info)
             }
-        )
+
+        results["metadata"] = metadata
+        results["rmats"] = np.array(self.raw_rmats)
 
         # collect information into EmittanceMeasurementResult object
         return QuadScanEmittanceResult(**results)
@@ -605,6 +608,9 @@ class QuadScanEmittance(Measurement):
             self.rmat.append(np.stack([rmat[0:2, 0:2], rmat[2:4, 2:4]]))
             if not self.design_twiss:
                 self.design_twiss = optics["design_twiss"]
+            if not self.rmats:
+                self.raw_rmats = []
+            self.raw_rmats.append(rmat)
 
     def _get_beamsizes_scan_values_from_info(self) -> ndarray:
         """
@@ -666,7 +672,7 @@ class MultiDeviceEmittance(EmittanceMeasurementBase):
 
         return beam_profiles, rmats, design_twiss
 
-    def construct_result(self, emittance_dict, beam_sizes):
+    def construct_result(self, emittance_dict, beam_sizes, rmats):
         """
 
         Calculate the emittance from the measured beam sizes and quadrupole strengths.
@@ -684,6 +690,7 @@ class MultiDeviceEmittance(EmittanceMeasurementBase):
             "beam_profile_devices_names": beam_profile_devices_names,
             "beam_profile_devices_z": beam_profile_devices_z,
             "rms_beamsizes": beam_sizes,
+            "rmats": rmats,
             "metadata": metadata,
         }
 

--- a/slac_measurements/emittance_measurement.py
+++ b/slac_measurements/emittance_measurement.py
@@ -86,9 +86,12 @@ class EmittanceMeasurementResult(slac_measurements.BaseModel):
     emittance: NDArrayAnnotatedType
     bmag: Optional[NDArrayAnnotatedType] = None
     twiss: NDArrayAnnotatedType
+    twiss_at_reconstruction: NDArrayAnnotatedType
     rmats: Optional[NDArrayAnnotatedType] = None
+    design_twiss: Optional[NDArrayAnnotatedType] = None
     rms_beamsizes: NDArrayAnnotatedType
     beam_matrix: NDArrayAnnotatedType
+    energy: float
     metadata: SerializeAsAny[Any]
 
 class MultiDeviceEmittanceResult(EmittanceMeasurementResult):
@@ -289,7 +292,7 @@ class EmittanceMeasurementBase(Measurement):
             beam_profiles, rmats, design_twiss, self.energy
         )
 
-        return self.construct_result(emittance_dict, beam_sizes, rmats)
+        return self.construct_result(emittance_dict, beam_sizes, rmats, design_twiss)
 
     @abstractmethod
     def retrieve_beam_profiles_and_optics(self):
@@ -542,9 +545,13 @@ class QuadScanEmittance(Measurement):
                 result = compute_emit_bmag(**emit_kwargs)
                 result["emittance"] = normalize_emittance(result["emittance"], self.energy)
 
-                result.update({"quadrupole_focusing_strengths": kmod_list[i]})
-                result.update({"quadrupole_pv_values": scan_values[i][idx]})
-                result.update({"rms_beamsizes": beam_sizes[i][idx]})
+                result.update(
+                    {
+                        "quadrupole_focusing_strengths": kmod_list[i],
+                        "quadrupole_pv_values": scan_values[i][idx],
+                        "rms_beamsizes": beam_sizes[i][idx] * 1e6,
+                    }
+                )
 
                 # add results to dict object
                 for name, value in result.items():
@@ -575,8 +582,14 @@ class QuadScanEmittance(Measurement):
                 for sval, ele in zip(self.scan_values, self._info)
             }
 
-        results["metadata"] = metadata
-        results["rmats"] = np.array(self.raw_rmats)
+        results.update(
+            {
+                "metadata": metadata,
+                "rmats": np.array(self.raw_rmats),
+                "design_twiss": self.design_twiss,
+                "energy": self.energy,
+            }
+        )
 
         # collect information into EmittanceMeasurementResult object
         return QuadScanEmittanceResult(**results)
@@ -672,7 +685,7 @@ class MultiDeviceEmittance(EmittanceMeasurementBase):
 
         return beam_profiles, rmats, design_twiss
 
-    def construct_result(self, emittance_dict, beam_sizes, rmats):
+    def construct_result(self, emittance_dict, beam_sizes, rmats, design_twiss):
         """
 
         Calculate the emittance from the measured beam sizes and quadrupole strengths.
@@ -691,6 +704,8 @@ class MultiDeviceEmittance(EmittanceMeasurementBase):
             "beam_profile_devices_z": beam_profile_devices_z,
             "rms_beamsizes": beam_sizes,
             "rmats": rmats,
+            "design_twiss": design_twiss,
+            "energy": self.energy,
             "metadata": metadata,
         }
 

--- a/slac_measurements/emittance_measurement.py
+++ b/slac_measurements/emittance_measurement.py
@@ -96,7 +96,7 @@ class EmittanceMeasurementResult(slac_measurements.BaseModel):
 
 class MultiDeviceEmittanceResult(EmittanceMeasurementResult):
     """
-    EmittanceMeasurementResult stores the results of an emittance measurement.
+    MultiDeviceEmittanceResult stores the results of an emittance measurement.
 
     Attributes
     ----------
@@ -130,7 +130,7 @@ class MultiDeviceEmittanceResult(EmittanceMeasurementResult):
 
 class QuadScanEmittanceResult(EmittanceMeasurementResult):
     """
-    EmittanceMeasurementResult stores the results of an emittance measurement.
+    QuadScanEmittanceResult stores the results of an emittance measurement.
 
     Attributes
     ----------

--- a/slac_measurements/emittance_measurement.py
+++ b/slac_measurements/emittance_measurement.py
@@ -697,7 +697,7 @@ class MultiDeviceEmittance(EmittanceMeasurementBase):
 
         """
         beam_profile_devices_names = [measurement.beam_profile_device.name for measurement in self.beamsize_measurements]
-        beam_profile_devices_z = [measurement.beam_profile_device.metadata.sum_l_meters for measurement in self.beamsize_measurements]
+        beam_profile_devices_z = [measurement.beam_profile_device.sum_l_meters for measurement in self.beamsize_measurements]
         metadata = self.model_dump()
         results_dict = emittance_dict | {
             "beam_profile_devices_names": beam_profile_devices_names,
@@ -874,6 +874,7 @@ def compute_emit_bmag_quad_scan_machine_units(
     # Prepare outputs
     results = {
         "emittance": [],
+        "twiss_at_reconstruction": [],
         "twiss": [],
         "beam_matrix": [],
         "bmag": [] if twiss_design is not None else None,

--- a/slac_measurements/emittance_measurement.py
+++ b/slac_measurements/emittance_measurement.py
@@ -24,7 +24,7 @@ from slac_measurements.model_general_calcs import (
     build_quad_rmat,
     bdes_to_kmod,
     multi_device_optics,
-    get_rmat_after_magnet,
+    get_optics_after_magnet,
     quad_scan_optics,
 )
 import slac_measurements
@@ -450,12 +450,14 @@ class QuadScanEmittance(Measurement):
         """
 
         if self.manual_quad_rmats:
-            drift_rmat = get_rmat_after_magnet(
+            optics = get_optics_after_magnet(
                 self.magnet,
-                self.beamsize_measurement,
+                self.beamsize_measurement.beam_profile_device,
                 self.physics_model,
             )
-            self.rmat = np.stack([drift_rmat[0:2, 0:2], drift_rmat[2:4, 2:4]])
+            after_quad_rmat = optics["after_quad_rmat"]
+            self.rmat = np.stack([after_quad_rmat[0:2, 0:2], after_quad_rmat[2:4, 2:4]])
+            self.design_twiss = optics["design_twiss"]
 
         if self.rmat is None or self.rmat.size == 0:
             self.rmat_given = False
@@ -613,7 +615,7 @@ class QuadScanEmittance(Measurement):
         if not self.rmat_given:
             optics = quad_scan_optics(
                 self.magnet,
-                self.beamsize_measurement,
+                self.beamsize_measurement.beam_profile_device,
                 self.physics_model,
             )
             rmat = optics["rmat"]
@@ -671,12 +673,14 @@ class MultiDeviceEmittance(EmittanceMeasurementBase):
         object attributes
 
         """
+        beam_profile_devices = []
         beam_profiles = []
         for beamsize_measurement in self.beamsize_measurements:
+            beam_profile_devices.append(beamsize_measurement.beam_profile_device)
             beam_profiles.append(beamsize_measurement.measure())
 
         optics = multi_device_optics(
-            self.beamsize_measurements,
+            beam_profile_devices,
             self.physics_model,
         )
 

--- a/slac_measurements/emittance_measurement.py
+++ b/slac_measurements/emittance_measurement.py
@@ -23,7 +23,7 @@ from slac_measurements.model_general_calcs import (
     build_quad_rmat,
     bdes_to_kmod,
     multi_device_optics,
-    get_optics_after_magnet,
+    get_rmat_after_magnet,
     quad_scan_optics,
 )
 import slac_measurements
@@ -444,14 +444,12 @@ class QuadScanEmittance(Measurement):
         """
 
         if self.manual_quad_rmats:
-            optics = get_optics_after_magnet(
+            drift_rmat = get_rmat_after_magnet(
                 self.magnet,
-                self.beamsize_measurement.beam_profile_device,
+                self.beamsize_measurement,
                 self.physics_model,
             )
-            after_quad_rmat = optics["after_quad_rmat"]
-            self.rmat = np.stack([after_quad_rmat[0:2, 0:2], after_quad_rmat[2:4, 2:4]])
-            self.design_twiss = optics["design_twiss"]
+            self.rmat = np.stack([drift_rmat[0:2, 0:2], drift_rmat[2:4, 2:4]])
 
         if self.rmat is None or self.rmat.size == 0:
             self.rmat_given = False
@@ -599,7 +597,7 @@ class QuadScanEmittance(Measurement):
         if not self.rmat_given:
             optics = quad_scan_optics(
                 self.magnet,
-                self.beamsize_measurement.beam_profile_device,
+                self.beamsize_measurement,
                 self.physics_model,
             )
             rmat = optics["rmat"]
@@ -654,14 +652,12 @@ class MultiDeviceEmittance(EmittanceMeasurementBase):
         object attributes
 
         """
-        beam_profile_devices = []
         beam_profiles = []
         for beamsize_measurement in self.beamsize_measurements:
-            beam_profile_devices.append(beamsize_measurement.beam_profile_device)
             beam_profiles.append(beamsize_measurement.measure())
 
         optics = multi_device_optics(
-            beam_profile_devices,
+            self.beamsize_measurements,
             self.physics_model,
         )
 

--- a/slac_measurements/model_general_calcs.py
+++ b/slac_measurements/model_general_calcs.py
@@ -97,7 +97,7 @@ def get_optics_after_magnet(
         to_device=magnet.name,
     )
     after_quad_rmat = full_rmat @ np.linalg.inv(quad_rmat)
-    model_design = _get_model_from_device(beam_profile_device, physics_model, use_design=False)
+    model_design = _get_model_from_device(beam_profile_device, physics_model, use_design=True)
     twiss = model_design.get_twiss(beam_profile_device.name)
     return {"after_quad_rmat": after_quad_rmat, "design_twiss": twiss}
 

--- a/slac_measurements/model_general_calcs.py
+++ b/slac_measurements/model_general_calcs.py
@@ -1,11 +1,9 @@
-from typing import Dict, Union
+from typing import Dict
 
 import numpy as np
 
 from slac_devices.magnet import Magnet
 
-from slac_devices.screen import Screen
-from slac_devices.wire import Wire
 from slac_measurements.beam_profile import BeamProfileMeasurement
 
 
@@ -63,62 +61,58 @@ def bdes_to_kmod(e_tot=None, effective_length=None, bdes=None, tao=None, element
 
 
 def quad_scan_optics(
-    magnet: Magnet, beam_profile_device: Union[Screen, Wire], physics_model="BMAD"
+    magnet: Magnet, measurement: BeamProfileMeasurement, physics_model="BLEM"
 ) -> Dict:
     """Get rmat (6 x 6) from magnet to measurement device and twiss at measurement device"""
     # TODO: get optics from arbitrary devices (potentially in different beam lines)
     # have live BLEM model update
     if physics_model == "BLEM":
         refresh_blem_model()
-    model_live = _get_model_from_device(beam_profile_device, physics_model, use_design=False)
-    rmat = model_live.get_rmat(
+    model = _get_model_from_device(measurement.beam_profile_device, physics_model)
+    rmat = model.get_rmat(
         from_device=magnet.name,
-        to_device=beam_profile_device.name,
+        to_device=measurement.beam_profile_device.name,
     )
-    model_design = _get_model_from_device(beam_profile_device, physics_model, use_design=True)
-    twiss = model_design.get_twiss(beam_profile_device.name)
+    twiss = model.get_twiss(measurement.beam_profile_device.name)
     return {"rmat": rmat, "design_twiss": twiss}
 
 
-def get_optics_after_magnet(
-    magnet: Magnet, beam_profile_device: Union[Screen, Wire], physics_model="BMAD"
-) -> Dict:
+def get_rmat_after_magnet(
+    magnet: Magnet, measurement: BeamProfileMeasurement, physics_model="BLEM"
+) -> np.ndarray:
     """Get rmat from end of magnet to measurement device"""
     # have live BLEM model update
     if physics_model == "BLEM":
         refresh_blem_model()
-    model_live = _get_model_from_device(beam_profile_device, physics_model, use_design=False)
-    full_rmat = model_live.get_rmat(
+    model = _get_model_from_device(measurement.beam_profile_device, physics_model)
+    full_rmat = model.get_rmat(
         from_device=magnet.name,
-        to_device=beam_profile_device.name,
+        to_device=measurement.beam_profile_device.name,
     )
-    quad_rmat = model_live.get_rmat(
+    quad_rmat = model.get_rmat(
         from_device=magnet.name,
         to_device=magnet.name,
     )
-    after_quad_rmat = full_rmat @ np.linalg.inv(quad_rmat)
-    model_design = _get_model_from_device(beam_profile_device, physics_model, use_design=False)
-    twiss = model_design.get_twiss(beam_profile_device.name)
-    return {"after_quad_rmat": after_quad_rmat, "design_twiss": twiss}
+    drift_rmat = full_rmat @ np.linalg.inv(quad_rmat)
+    return drift_rmat
 
 
 def multi_device_optics(
-    beam_profile_devices: list[Union[Screen, Wire]], physics_model="BMAD"
+    measurements: list[BeamProfileMeasurement], physics_model="BLEM"
 ) -> Dict:
     """Get rmat and twiss from reference device to all measurement devices"""
-    model_live = _get_model_from_device(beam_profile_devices[-1], physics_model, use_design=False)
+    model = _get_model_from_device(measurements[-1].beam_profile_device, physics_model)
     beam_profile_device_names = [
-        beam_profile_device.name for beam_profile_device in beam_profile_devices
+        measurement.beam_profile_device.name for measurement in measurements
     ]
     rmat = []
     ref_index = int(len(beam_profile_device_names) / 2)
     device_ref = beam_profile_device_names[ref_index]
     for device in beam_profile_device_names:
-        rmat.append(model_live.get_rmat(device_ref, device))
+        rmat.append(model.get_rmat(device_ref, device))
     rmat = np.array(rmat)
-    model_design = _get_model_from_device(beam_profile_devices[-1], physics_model, use_design=True)
-    twiss = model_design.get_twiss(beam_profile_device_names)
-    return {"rmat": rmat, "design_twiss": twiss}
+    twiss = model.get_twiss(beam_profile_device_names)
+    return {"rmat": rmat, "lattice_twiss": twiss}
 
 
 def refresh_blem_model():
@@ -138,7 +132,7 @@ def refresh_blem_model():
     done.wait()  # blocks until ctrl PV has reset to 0
 
 
-def _get_model_from_device(device, physics_model, use_design=False):
+def _get_model_from_device(device, physics_model):
     from meme.model import Model
 
     # Look for device beam path in meme beam paths
@@ -159,7 +153,7 @@ def _get_model_from_device(device, physics_model, use_design=False):
     if beam_path is None:
         raise ValueError("Valid beam path not found in device metadata.")
 
-    return Model(beam_path, model_source=physics_model, use_design=use_design)
+    return Model(beam_path, model_source=physics_model, use_design=False)
 
 
 def propagate_twiss(twiss_init: np.ndarray, rmat: np.ndarray):

--- a/slac_measurements/model_general_calcs.py
+++ b/slac_measurements/model_general_calcs.py
@@ -1,9 +1,11 @@
-from typing import Dict
+from typing import Dict, Union
 
 import numpy as np
 
 from slac_devices.magnet import Magnet
 
+from slac_devices.screen import Screen
+from slac_devices.wire import Wire
 from slac_measurements.beam_profile import BeamProfileMeasurement
 
 
@@ -61,60 +63,62 @@ def bdes_to_kmod(e_tot=None, effective_length=None, bdes=None, tao=None, element
 
 
 def quad_scan_optics(
-    magnet: Magnet, measurement: BeamProfileMeasurement, physics_model="BLEM"
+    magnet: Magnet, beam_profile_device: Union[Screen, Wire], physics_model="BMAD"
 ) -> Dict:
     """Get rmat (6 x 6) from magnet to measurement device and twiss at measurement device"""
     # TODO: get optics from arbitrary devices (potentially in different beam lines)
     # have live BLEM model update
     if physics_model == "BLEM":
         refresh_blem_model()
-    model = _get_model_from_device(measurement.beam_profile_device, physics_model)
-    rmat = model.get_rmat(
+    model_live = _get_model_from_device(beam_profile_device, physics_model, use_design=False)
+    rmat = model_live.get_rmat(
         from_device=magnet.name,
-        to_device=measurement.beam_profile_device.name,
+        to_device=beam_profile_device.name,
     )
-    twiss = model.get_twiss(measurement.beam_profile_device.name)
+    model_design = _get_model_from_device(beam_profile_device, physics_model, use_design=True)
+    twiss = model_design.get_twiss(beam_profile_device.name)
     return {"rmat": rmat, "design_twiss": twiss}
 
 
-def get_rmat_after_magnet(
-    magnet: Magnet, measurement: BeamProfileMeasurement, physics_model="BLEM"
-) -> np.ndarray:
+def get_optics_after_magnet(
+    magnet: Magnet, beam_profile_device: Union[Screen, Wire], physics_model="BMAD"
+) -> Dict:
     """Get rmat from end of magnet to measurement device"""
     # have live BLEM model update
     if physics_model == "BLEM":
         refresh_blem_model()
-    model = _get_model_from_device(measurement.beam_profile_device, physics_model)
-    full_rmat = model.get_rmat(
+    model_live = _get_model_from_device(beam_profile_device, physics_model, use_design=False)
+    full_rmat = model_live.get_rmat(
         from_device=magnet.name,
-        to_device=measurement.beam_profile_device.name,
+        to_device=beam_profile_device.name,
     )
-    quad_rmat = model.get_rmat(
+    quad_rmat = model_live.get_rmat(
         from_device=magnet.name,
         to_device=magnet.name,
     )
     after_quad_rmat = full_rmat @ np.linalg.inv(quad_rmat)
-    model_design = _get_model_from_device(beam_profile_device, physics_model, use_design=True)
+    model_design = _get_model_from_device(beam_profile_device, physics_model, use_design=False)
     twiss = model_design.get_twiss(beam_profile_device.name)
     return {"after_quad_rmat": after_quad_rmat, "design_twiss": twiss}
 
 
 def multi_device_optics(
-    measurements: list[BeamProfileMeasurement], physics_model="BLEM"
+    beam_profile_devices: list[Union[Screen, Wire]], physics_model="BMAD"
 ) -> Dict:
     """Get rmat and twiss from reference device to all measurement devices"""
-    model = _get_model_from_device(measurements[-1].beam_profile_device, physics_model)
+    model_live = _get_model_from_device(beam_profile_devices[-1], physics_model, use_design=False)
     beam_profile_device_names = [
-        measurement.beam_profile_device.name for measurement in measurements
+        beam_profile_device.name for beam_profile_device in beam_profile_devices
     ]
     rmat = []
     ref_index = int(len(beam_profile_device_names) / 2)
     device_ref = beam_profile_device_names[ref_index]
     for device in beam_profile_device_names:
-        rmat.append(model.get_rmat(device_ref, device))
+        rmat.append(model_live.get_rmat(device_ref, device))
     rmat = np.array(rmat)
-    twiss = model.get_twiss(beam_profile_device_names)
-    return {"rmat": rmat, "lattice_twiss": twiss}
+    model_design = _get_model_from_device(beam_profile_devices[-1], physics_model, use_design=True)
+    twiss = model_design.get_twiss(beam_profile_device_names)
+    return {"rmat": rmat, "design_twiss": twiss}
 
 
 def refresh_blem_model():
@@ -134,7 +138,7 @@ def refresh_blem_model():
     done.wait()  # blocks until ctrl PV has reset to 0
 
 
-def _get_model_from_device(device, physics_model):
+def _get_model_from_device(device, physics_model, use_design=False):
     from meme.model import Model
 
     # Look for device beam path in meme beam paths
@@ -155,7 +159,7 @@ def _get_model_from_device(device, physics_model):
     if beam_path is None:
         raise ValueError("Valid beam path not found in device metadata.")
 
-    return Model(beam_path, model_source=physics_model, use_design=False)
+    return Model(beam_path, model_source=physics_model, use_design=use_design)
 
 
 def propagate_twiss(twiss_init: np.ndarray, rmat: np.ndarray):

--- a/tests/test_emittance_measurement.py
+++ b/tests/test_emittance_measurement.py
@@ -351,12 +351,14 @@ class MultiDeviceEmittanceTest(TestCase):
         profmon_measurement_1 = Mock(spec=ScreenBeamProfileMeasurement)
         profmon_measurement_1.beam_profile_device = Mock(spec=Screen)
         profmon_measurement_1.beam_profile_device.name = "OTR1"
+        profmon_measurement_1.beam_profile_device.sum_l_meters = 500.0
         profmon_measurement_return_value = Mock(spec=ScreenBeamProfileMeasurementResult)
         profmon_measurement_return_value.rms_sizes = np.array([50.0, 50.0])
         profmon_measurement_1.measure.return_value = profmon_measurement_return_value
         profmon_measurement_2 = Mock(spec=ScreenBeamProfileMeasurement)
         profmon_measurement_2.beam_profile_device = Mock(spec=Screen)
         profmon_measurement_2.beam_profile_device.name = "OTR2"
+        profmon_measurement_2.beam_profile_device.sum_l_meters = 520.0
         profmon_measurement_2_return_value = Mock(
             spec=ScreenBeamProfileMeasurementResult
         )
@@ -365,10 +367,12 @@ class MultiDeviceEmittanceTest(TestCase):
         profmon_measurement_3 = Mock(spec=ScreenBeamProfileMeasurement)
         profmon_measurement_3.beam_profile_device = Mock(spec=Screen)
         profmon_measurement_3.beam_profile_device.name = "OTR3"
+        profmon_measurement_3.beam_profile_device.sum_l_meters = 540.0
         profmon_measurement_3.measure.return_value = profmon_measurement_return_value
         profmon_measurement_4 = Mock(spec=ScreenBeamProfileMeasurement)
         profmon_measurement_4.beam_profile_device = Mock(spec=Screen)
         profmon_measurement_4.beam_profile_device.name = "OTR4"
+        profmon_measurement_4.beam_profile_device.sum_l_meters = 560.0
         profmon_measurement_4.measure.return_value = profmon_measurement_return_value
         beamsize_measurements = [
             profmon_measurement_1,


### PR DESCRIPTION
This PR adds the MultiDeviceEmittanceResult. It specifically has the beam profile device names and z locations, which are used for the beam size plots.

In addition, the twiss parameters at the reconstruction location, 6 x 6 rmats collected during the measurement, design twiss parameters (at the screen/wire in a quad scan or at the reference beam profile device in a multi measurement), and energy are being added to the EmittanceMeasurementResult.

There are also a couple minor refactoring changes
- the metadata attribute in the QuadScanEmittanceResult only gets resolution and image_data keys if a screen is used
- the default physics_model in the QuadScanEmittance class has been changed to BLEM (this is for convenience when using the GUI, but soon this won't matter when the GUI can select the physics model)