### PR TITLE
Refactor TMITLoss class and improve BPM data handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
     "pyyaml",
     "pydantic",
     "h5py",
-    "pandas",
     "scikit-image",
     "torch",
     "slac-devices @ git+https://github.com/slaclab/slac-devices.git@main"

--- a/slac_measurements/tmit_loss.py
+++ b/slac_measurements/tmit_loss.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+import epics
 import numpy as np
 from pydantic import model_validator
 from slac_devices.reader import create_beampath
@@ -51,15 +52,17 @@ class TMITLoss(Measurement):
             f"{bpm.controls_information.control_name}:TMIT"
             for bpm in self.bpms.values()
         ]
-        buff_data = self.buffer.get_buffer(pv_names)
+        hst_pvs = [f"{pv}HST{self.buffer.number}" for pv in pv_names]
+        results = epics.caget_many(hst_pvs)
 
         n_samples = self.buffer.n_measurements
         rows = []
-        for name, pv_name in zip(self.bpms.keys(), pv_names):
-            data = buff_data.get(pv_name)
+        for name, data in zip(self.bpms.keys(), results):
             if data is None:
-                print(f"Skipping BPM {name}: no buffer data for {pv_name}")
+                print(f"Skipping BPM {name}: no buffer data")
                 data = np.full(n_samples, np.nan)
+            else:
+                data = data[:n_samples]
             rows.append(data)
         return np.array(rows)
 

--- a/slac_measurements/tmit_loss.py
+++ b/slac_measurements/tmit_loss.py
@@ -1,11 +1,11 @@
+import gc
+
 import numpy as np
 from slac_devices.reader import create_beampath
 from slac_devices.wire import Wire
 from slac_measurements.measurement import Measurement
 from slac_measurements.utils import collect_with_size_check
 from edef import BSABuffer, EventDefinition
-from pydantic import model_validator
-from typing import Optional
 
 
 class TMITLoss(Measurement):
@@ -16,51 +16,39 @@ class TMITLoss(Measurement):
     beampath: str
     beam_profile_device: Wire
 
-    idx_upstream: Optional[list] = None
-    idx_downstream: Optional[list] = None
-    bpms: Optional[dict] = None
-
-    @model_validator(mode="after")
-    def run_setup(self) -> "TMITLoss":
-        """Load BPMs from beampath and resolve before/after wire indices."""
-
-        def _build_bpm_lookup() -> dict:
-            """Instantiate all BPMs in the beampath, sorted by z-position."""
-            beampath_obj = create_beampath(self.beampath)
-            all_bpms = beampath_obj.bpms
-            if not all_bpms:
-                raise LookupError("No BPMs found in beampath.")
-            return dict(sorted(all_bpms.items(), key=lambda item: item[1].z_location))
-
-        def _resolve_wire_bpms() -> tuple:
-            """Map wire metadata BPM names to row indices in the data array."""
-            bpms_upstream = self.beam_profile_device.metadata.tmitloss.upstream
-            bpms_downstream = self.beam_profile_device.metadata.tmitloss.downstream
-
-            bpm_names = list(self.bpms.keys())
-            idx_upstream = [
-                bpm_names.index(name) for name in bpms_upstream if name in self.bpms
-            ]
-            idx_downstream = [
-                bpm_names.index(name) for name in bpms_downstream if name in self.bpms
-            ]
-
-            return idx_upstream, idx_downstream
-
-        self.bpms = _build_bpm_lookup()
-        self.idx_upstream, self.idx_downstream = _resolve_wire_bpms()
-        return self
-
     def measure(self):
         """Acquire TMIT data and return percentage loss as a numpy array."""
-        data = self.get_bpm_data()
-        return self.calc_tmit_loss(data)
+        bpms, idx_upstream, idx_downstream = self._build_bpm_state()
+        try:
+            data = self._get_bpm_data(bpms)
+            return self._calc_tmit_loss(data, idx_upstream, idx_downstream)
+        finally:
+            del bpms
+            gc.collect()
 
-    def get_bpm_data(self) -> np.ndarray:
+    def _build_bpm_state(self) -> tuple:
+        """Instantiate BPMs from beampath and resolve upstream/downstream indices."""
+        beampath_obj = create_beampath(self.beampath)
+        all_bpms = beampath_obj.bpms
+        if not all_bpms:
+            raise LookupError("No BPMs found in beampath.")
+        bpms = dict(sorted(all_bpms.items(), key=lambda item: item[1].z_location))
+
+        bpms_upstream = self.beam_profile_device.metadata.tmitloss.upstream
+        bpms_downstream = self.beam_profile_device.metadata.tmitloss.downstream
+        bpm_names = list(bpms.keys())
+        idx_upstream = [bpm_names.index(name) for name in bpms_upstream if name in bpms]
+        idx_downstream = [
+            bpm_names.index(name) for name in bpms_downstream if name in bpms
+        ]
+
+        return bpms, idx_upstream, idx_downstream
+
+    def _get_bpm_data(self, bpms: dict) -> np.ndarray:
         """Collect TMIT buffer data from all BPMs. Returns shape (n_bpms, n_samples)."""
         rows = []
         n_samples = self.buffer.n_measurements
-        for name, bpm in self.bpms.items():
+        for name, bpm in bpms.items():
             try:
                 bpm_data = collect_with_size_check(
                     bpm, "tmit_buffer", self.buffer, None
@@ -71,15 +59,18 @@ class TMITLoss(Measurement):
             rows.append(bpm_data)
         return np.array(rows)
 
-    def calc_tmit_loss(self, data: np.ndarray) -> np.ndarray:
+    @staticmethod
+    def _calc_tmit_loss(
+        data: np.ndarray, idx_upstream: list, idx_downstream: list
+    ) -> np.ndarray:
         """Normalize TMIT data and compute percentage loss between before/after wire BPMs."""
         row_medians = np.nanmedian(data, axis=1, keepdims=True)
         ironed = data / row_medians
 
-        mean_iron_upstream = np.nanmean(ironed[self.idx_upstream], axis=0)
+        mean_iron_upstream = np.nanmean(ironed[idx_upstream], axis=0)
         normed = ironed / mean_iron_upstream
 
-        mean_upstream = np.nanmean(normed[self.idx_upstream], axis=0)
-        mean_downstream = np.nanmean(normed[self.idx_downstream], axis=0)
+        mean_upstream = np.nanmean(normed[idx_upstream], axis=0)
+        mean_downstream = np.nanmean(normed[idx_downstream], axis=0)
 
         return (mean_upstream - mean_downstream) * 100

--- a/slac_measurements/tmit_loss.py
+++ b/slac_measurements/tmit_loss.py
@@ -28,7 +28,7 @@ class TMITLoss(Measurement):
 
     def _build_bpm_state(self) -> tuple:
         """Instantiate BPMs from beampath and resolve upstream/downstream indices."""
-        beampath_obj = create_beampath(self.beampath)
+        beampath_obj = create_beampath(self.beampath, device_types={"bpms"})
         all_bpms = beampath_obj.bpms
         if not all_bpms:
             raise LookupError("No BPMs found in beampath.")

--- a/slac_measurements/tmit_loss.py
+++ b/slac_measurements/tmit_loss.py
@@ -5,7 +5,6 @@ from pydantic import model_validator
 from slac_devices.reader import create_beampath
 from slac_devices.wire import Wire
 from slac_measurements.measurement import Measurement
-from slac_measurements.utils import collect_with_size_check
 from edef import BSABuffer, EventDefinition
 
 
@@ -48,17 +47,20 @@ class TMITLoss(Measurement):
 
     def _get_bpm_data(self) -> np.ndarray:
         """Collect TMIT buffer data from all BPMs. Returns shape (n_bpms, n_samples)."""
-        rows = []
+        pv_names = [
+            f"{bpm.controls_information.control_name}:TMIT"
+            for bpm in self.bpms.values()
+        ]
+        buff_data = self.buffer.get_buffer(pv_names)
+
         n_samples = self.buffer.n_measurements
-        for name, bpm in self.bpms.items():
-            try:
-                bpm_data = collect_with_size_check(
-                    bpm, "tmit_buffer", self.buffer, None
-                )
-            except (TypeError, BufferError) as e:
-                print(f"Skipping BPM {name}: {e}")
-                bpm_data = np.full(n_samples, np.nan)
-            rows.append(bpm_data)
+        rows = []
+        for name, pv_name in zip(self.bpms.keys(), pv_names):
+            data = buff_data.get(pv_name)
+            if data is None:
+                print(f"Skipping BPM {name}: no buffer data for {pv_name}")
+                data = np.full(n_samples, np.nan)
+            rows.append(data)
         return np.array(rows)
 
     @staticmethod

--- a/slac_measurements/tmit_loss.py
+++ b/slac_measurements/tmit_loss.py
@@ -58,12 +58,17 @@ class TMITLoss(Measurement):
         n_samples = self.buffer.n_measurements
         rows = []
         for name, data in zip(self.bpms.keys(), results):
-            if data is None:
-                print(f"Skipping BPM {name}: no buffer data")
-                data = np.full(n_samples, np.nan)
+            if data is None or len(data) < n_samples:
+                if data is not None:
+                    print(
+                        f"Skipping BPM {name}: incomplete data ({len(data)}/{n_samples})"
+                    )
+                else:
+                    print(f"Skipping BPM {name}: no buffer data")
+                row = np.full(n_samples, np.nan)
             else:
-                data = data[:n_samples]
-            rows.append(data)
+                row = np.asarray(data[:n_samples], dtype=float)
+            rows.append(row)
         return np.array(rows)
 
     @staticmethod

--- a/slac_measurements/tmit_loss.py
+++ b/slac_measurements/tmit_loss.py
@@ -44,9 +44,7 @@ class TMITLoss(Measurement):
 
         self._hst_pvs = [
             epics.PV(
-                self.buffer.buffer_pv(
-                    pv=bpm.controls_information.PVs.tmit.pvname, suffix="HST"
-                )
+                f"{bpm.controls_information.PVs.tmit.pvname}HST{self.buffer.number}"
             )
             for bpm in self.bpms.values()
         ]

--- a/slac_measurements/tmit_loss.py
+++ b/slac_measurements/tmit_loss.py
@@ -1,253 +1,86 @@
-from slac_devices.reader import create_bpm
+import numpy as np
+from slac_devices.reader import create_beampath
+from slac_devices.wire import Wire
 from slac_measurements.measurement import Measurement
 from slac_measurements.utils import collect_with_size_check
-import pandas as pd
 from edef import BSABuffer
-from slac_devices.wire import Wire
 from pydantic import model_validator
 from typing import Optional
 
 
 class TMITLoss(Measurement):
-    name: str = "TMIT Loss Beam Size"
-    my_buffer: BSABuffer
+    name: str = "TMIT Loss"
+    buffer: BSABuffer
     beampath: str
     region: str
     beam_profile_device: Wire
 
-    # Extra fields to be set after validation
     idx_before: Optional[list] = None
     idx_after: Optional[list] = None
     bpms: Optional[dict] = None
 
     @model_validator(mode="after")
     def run_setup(self) -> "TMITLoss":
-        bpms_elements, bpms_devices = self.find_bpms()
-        self.idx_before, self.idx_after = self.get_bpm_idx(bpms_devices)
-        self.bpms = self.create_bpms(bpms_elements)
+        def _build_bpm_lookup() -> dict:
+            beampath_obj = create_beampath(self.beampath)
+            all_bpms = beampath_obj.bpms
+            if not all_bpms:
+                raise LookupError("No BPMs found in beampath.")
+            return dict(sorted(all_bpms.items(), key=lambda item: item[1].z_location))
+
+        def _resolve_wire_bpms() -> tuple:
+            tmit_regions = {
+                "HTR",
+                "DIAG0",
+                "COL1",
+                "EMIT2",
+                "DOG",
+                "BYP",
+                "SPD",
+                "LTUS",
+            }
+            if self.region not in tmit_regions:
+                valid_regions_str = ", ".join(sorted(tmit_regions))
+                raise ValueError(
+                    f"Invalid region '{self.region}'. Must be one of {valid_regions_str}."
+                )
+
+            bpms_before = self.beam_profile_device.metadata.bpms_before_wire
+            bpms_after = self.beam_profile_device.metadata.bpms_after_wire
+
+            bpm_names = list(self.bpms.keys())
+            idx_before = [
+                bpm_names.index(name) for name in bpms_before if name in self.bpms
+            ]
+            idx_after = [
+                bpm_names.index(name) for name in bpms_after if name in self.bpms
+            ]
+
+            return idx_before, idx_after
+
+        self.bpms = _build_bpm_lookup()
+        self.idx_before, self.idx_after = _resolve_wire_bpms()
         return self
 
     def measure(self):
-        """
-        Compute the TMIT loss for a given beam path and region.
-
-        This method orchestrates the full process of acquiring BPM data,
-        normalizing it, and calculating TMIT loss by:
-        - Reserving a data buffer.
-        - Retrieving BPM elements and device names.
-        - Identifying BPM indices before and after the wire.
-        - Creating BPM objects.
-        - Collecting TMIT data.
-        - Computing the TMIT loss.
-
-        Args:
-            beampath (str): The beam path used to filter BPM elements.
-            region (str): The region of interest, which determines the BPMs
-                          used for before/after wire measurements.
-
-        Returns:
-            pd.Series: A Series representing the percentage TMIT loss for each
-                       time sample.
-        """
-        # Retrieve data from BSA buffer
         data = self.get_bpm_data()
+        return self.calc_tmit_loss(data)
 
-        # Calculate TMIT Loss
-        tmit_loss_pd = self.calc_tmit_loss(data)
-        tmit_loss = tmit_loss_pd.to_numpy()
-        return tmit_loss
+    def get_bpm_data(self) -> np.ndarray:
+        rows = []
+        for bpm in self.bpms.values():
+            bpm_data = collect_with_size_check(bpm, "tmit_buffer", self.buffer, None)
+            rows.append(bpm_data)
+        return np.array(rows)
 
-    def find_bpms(self):
-        """
-        Retrieve BPM elements and their corresponding EPICS names for a
-        given beam path.
+    def calc_tmit_loss(self, data: np.ndarray) -> np.ndarray:
+        row_medians = np.median(data, axis=1, keepdims=True)
+        ironed = data / row_medians
 
-        This method queries BPM elements and devices using the `meme.names`
-        module.  It extracts the area from each BPM device name and replaces
-        any area containing "BPN" with "BYP" for proper YAML file lookup.
+        mean_iron_before = ironed[self.idx_before].mean(axis=0)
+        normed = ironed / mean_iron_before
 
-        Args:
-            beampath (str): The beam path tag used to filter BPM elements
-            and devices.
+        mean_before = normed[self.idx_before].mean(axis=0)
+        mean_after = normed[self.idx_after].mean(axis=0)
 
-        Returns:
-            tuple: A tuple containing:
-                - pd.DataFrame: A DataFrame with BPM elements and their
-                                corresponding areas.
-                - list: A list of BPM device names.
-        """
-        import meme.names
-
-        # List of BPM MAD names based on beampath
-        bpms_elements = meme.names.list_elements(
-            "BPMS:%TMIT", tag=self.beampath, sort_by="z"
-        )
-
-        # List of BPM EPICS names based on beampath
-        bpms_devices = meme.names.list_devices(
-            "BPMS:%TMIT", tag=self.beampath, sort_by="z"
-        )
-
-        # Make Dataframe with two columns: First is the Element (MAD) name
-        # Second column is the area
-        areas_bpn = [device.split(":")[1] for device in bpms_devices]
-        # If EPICS name uses "BPN" for area, instead use "BYP"
-        areas = ["BYP" if "BPN" in item else item for item in areas_bpn]
-        bpms_elements = pd.DataFrame({"Element": bpms_elements, "Area": areas})
-        return bpms_elements, bpms_devices
-
-    def create_bpms(self, bpms_elements):
-        """
-        Create BPM device objects for a given set of BPM elements.
-
-        This method iterates through a DataFrame of BPM elements
-        and their corresponding areas, creating BPM objects
-        using the `create_bpm` function.
-
-        Args:
-            bpms_elements (pd.DataFrame): A DataFrame containing BPM
-                                          element names and their
-                                          associated areas. Must
-                                          have columns:
-                                          - 'Element' (str): The BPM
-                                            element name.
-                                          - 'Area' (str): The area
-                                            associated with the BPM.
-
-        Returns:
-            dict: A dictionary where the keys are BPM element
-            names and the values are the corresponding BPM
-            objects created using `create_bpm`.
-        """
-        bpm_obj_dict = {}
-
-        # Iterate through Dataframe of Elements and Areas
-        for _, row in bpms_elements.iterrows():
-            element = row["Element"]
-            area = row["Area"]
-
-            # Create an lcls-tools BPM object and append to dictionary
-            bpm = create_bpm(name=element, area=area)
-            if bpm is not None:
-                bpm_obj_dict[element] = bpm
-
-        if bpm_obj_dict:
-            return bpm_obj_dict
-        else:
-            raise LookupError("No BPM objects could be created.")
-
-    def get_bpm_data(self):
-        """
-        Retrieve TMIT buffer data for a set of BPMs.
-
-        This method iterates through a dictionary of BPM objects and attempts
-        to fetch their TMIT buffer data using a specified buffer. If data
-        retrieval fails for a BPM, it is assigned a `None` value.
-
-        Args:
-            bpm_obj_dict (dict): A dictionary where keys are BPM element
-                                 names (str) and values are BPM objects.
-            my_buffer (BSABuffer): The buffer used to retrieve TMIT data for
-                                 each BPM.
-
-        Returns:
-            pd.DataFrame: A transposed DataFrame where:
-                          - Rows correspond to BPM elements.
-                          - Columns contain the retrieved TMIT buffer data.
-        """
-        data = {}
-
-        for element, bpm in self.bpms.items():
-            bpm_data = collect_with_size_check(
-                bpm,
-                "tmit_buffer",
-                self.my_buffer,
-                None,
-            )
-            data[element] = bpm_data
-
-        df = pd.DataFrame(data)
-        return df.T
-
-    def get_bpm_idx(self, bpms_devices):
-        """
-        Retrieve the index positions of BPMs before and after the wire for a
-        given region.
-
-        This method selects predefined BPMs based on the specified region and
-        finds their corresponding indices in `bpms_devices`.
-
-        Args:
-            region (str): The region of interest. Must be one of:
-                          - "HTR", "DIAG0", "COL1", "EMIT2", "BYP",
-                            "SPD", "LTUS".
-            bpms_devices (list): A list of BPM device names.
-
-        Returns:
-            tuple: A tuple containing:
-                - list: Indices of BPMs located **before** the wire.
-                - list: Indices of BPMs located **after** the wire.
-        """
-        # Define valid regions
-        tmit_regions = {"HTR", "DIAG0", "COL1", "EMIT2", "DOG", "BYP", "SPD", "LTUS"}
-        if self.region not in tmit_regions:
-            valid_regions_str = ", ".join(sorted(tmit_regions))
-            raise ValueError(
-                f"Invalid region '{self.region}'. Must be one of {valid_regions_str}."
-            )
-
-        bpms_before_wire = self.beam_profile_device.metadata.bpms_before_wire
-        bpms_after_wire = self.beam_profile_device.metadata.bpms_after_wire
-
-        # Create a lookup dictionary for index mapping
-        idx_map = {value: idx for idx, value in enumerate(bpms_devices)}
-
-        # Find indices of BPMs before and after the wire
-        idx_before = [idx_map[item] for item in bpms_before_wire if item in idx_map]
-        idx_after = [idx_map[item] for item in bpms_after_wire if item in idx_map]
-
-        return idx_before, idx_after
-
-    def calc_tmit_loss(self, df):
-        """
-        Calculate the TMIT loss.
-
-        This method normalizes the TMIT data by computing row-wise medians,
-        then standardizes it relative to BPMs before a wire. The loss is
-        computed as the percentage change in mean TMIT values before and
-        after the wire.
-
-        Args:
-            df (pd.DataFrame): A DataFrame containing TMIT values, where
-                               rows correspond to BPMs and columns to
-                               time samples.
-            idx_before (list): List of row indices corresponding to BPMs
-                               before the wire.
-            idx_after (list): List of row indices corresponding to BPMs
-                              after the wire.
-
-        Returns:
-            pd.Series: A Series representing the percentage TMIT loss for each
-                       time sample.
-        """
-        # Compute row-wise medians and normalize the DataFrame
-        row_medians = df.median(axis=1)
-        df_ironed = df.div(row_medians, axis=0)
-
-        # Compute mean ironed TMIT for BPMs before the wire
-        ironed_before = df_ironed.iloc[self.idx_before, :]
-        mean_iron_before = ironed_before.mean()
-
-        # Normalize by mean TMIT before the wire
-        df_normed = df_ironed.div(mean_iron_before, axis=1)
-
-        # Compute mean ratios before and after the wire
-        normed_before = df_normed.iloc[self.idx_before]
-        normed_after = df_normed.iloc[self.idx_after]
-
-        mean_before = normed_before.mean()
-        mean_after = normed_after.mean()
-
-        # Compute TMIT Loss percentage
-        tmit_loss = (mean_before - mean_after) * 100
-        return tmit_loss
+        return (mean_before - mean_after) * 100

--- a/slac_measurements/tmit_loss.py
+++ b/slac_measurements/tmit_loss.py
@@ -59,20 +59,27 @@ class TMITLoss(Measurement):
     def get_bpm_data(self) -> np.ndarray:
         """Collect TMIT buffer data from all BPMs. Returns shape (n_bpms, n_samples)."""
         rows = []
-        for bpm in self.bpms.values():
-            bpm_data = collect_with_size_check(bpm, "tmit_buffer", self.buffer, None)
+        n_samples = self.buffer.n_measurements
+        for name, bpm in self.bpms.items():
+            try:
+                bpm_data = collect_with_size_check(
+                    bpm, "tmit_buffer", self.buffer, None
+                )
+            except (TypeError, BufferError) as e:
+                print(f"Skipping BPM {name}: {e}")
+                bpm_data = np.full(n_samples, np.nan)
             rows.append(bpm_data)
         return np.array(rows)
 
     def calc_tmit_loss(self, data: np.ndarray) -> np.ndarray:
         """Normalize TMIT data and compute percentage loss between before/after wire BPMs."""
-        row_medians = np.median(data, axis=1, keepdims=True)
+        row_medians = np.nanmedian(data, axis=1, keepdims=True)
         ironed = data / row_medians
 
-        mean_iron_upstream = ironed[self.idx_upstream].mean(axis=0)
+        mean_iron_upstream = np.nanmean(ironed[self.idx_upstream], axis=0)
         normed = ironed / mean_iron_upstream
 
-        mean_upstream = normed[self.idx_upstream].mean(axis=0)
-        mean_downstream = normed[self.idx_downstream].mean(axis=0)
+        mean_upstream = np.nanmean(normed[self.idx_upstream], axis=0)
+        mean_downstream = np.nanmean(normed[self.idx_downstream], axis=0)
 
         return (mean_upstream - mean_downstream) * 100

--- a/slac_measurements/tmit_loss.py
+++ b/slac_measurements/tmit_loss.py
@@ -1,4 +1,3 @@
-import gc
 from typing import Optional
 
 import numpy as np
@@ -44,14 +43,8 @@ class TMITLoss(Measurement):
 
     def measure(self):
         """Acquire TMIT data and return percentage loss as a numpy array."""
-        try:
-            data = self._get_bpm_data()
-            return self._calc_tmit_loss(data, self.idx_upstream, self.idx_downstream)
-        finally:
-            self.bpms = None
-            self.idx_upstream = None
-            self.idx_downstream = None
-            gc.collect()
+        data = self._get_bpm_data()
+        return self._calc_tmit_loss(data, self.idx_upstream, self.idx_downstream)
 
     def _get_bpm_data(self) -> np.ndarray:
         """Collect TMIT buffer data from all BPMs. Returns shape (n_bpms, n_samples)."""

--- a/slac_measurements/tmit_loss.py
+++ b/slac_measurements/tmit_loss.py
@@ -9,10 +9,11 @@ from typing import Optional
 
 
 class TMITLoss(Measurement):
+    """Measures percentage beam intensity loss across a wire scanner."""
+
     name: str = "TMIT Loss"
     buffer: BSABuffer
     beampath: str
-    region: str
     beam_profile_device: Wire
 
     idx_before: Optional[list] = None
@@ -21,7 +22,10 @@ class TMITLoss(Measurement):
 
     @model_validator(mode="after")
     def run_setup(self) -> "TMITLoss":
+        """Load BPMs from beampath and resolve before/after wire indices."""
+
         def _build_bpm_lookup() -> dict:
+            """Instantiate all BPMs in the beampath, sorted by z-position."""
             beampath_obj = create_beampath(self.beampath)
             all_bpms = beampath_obj.bpms
             if not all_bpms:
@@ -29,22 +33,7 @@ class TMITLoss(Measurement):
             return dict(sorted(all_bpms.items(), key=lambda item: item[1].z_location))
 
         def _resolve_wire_bpms() -> tuple:
-            tmit_regions = {
-                "HTR",
-                "DIAG0",
-                "COL1",
-                "EMIT2",
-                "DOG",
-                "BYP",
-                "SPD",
-                "LTUS",
-            }
-            if self.region not in tmit_regions:
-                valid_regions_str = ", ".join(sorted(tmit_regions))
-                raise ValueError(
-                    f"Invalid region '{self.region}'. Must be one of {valid_regions_str}."
-                )
-
+            """Map wire metadata BPM names to row indices in the data array."""
             bpms_before = self.beam_profile_device.metadata.bpms_before_wire
             bpms_after = self.beam_profile_device.metadata.bpms_after_wire
 
@@ -63,10 +52,12 @@ class TMITLoss(Measurement):
         return self
 
     def measure(self):
+        """Acquire TMIT data and return percentage loss as a numpy array."""
         data = self.get_bpm_data()
         return self.calc_tmit_loss(data)
 
     def get_bpm_data(self) -> np.ndarray:
+        """Collect TMIT buffer data from all BPMs. Returns shape (n_bpms, n_samples)."""
         rows = []
         for bpm in self.bpms.values():
             bpm_data = collect_with_size_check(bpm, "tmit_buffer", self.buffer, None)
@@ -74,6 +65,7 @@ class TMITLoss(Measurement):
         return np.array(rows)
 
     def calc_tmit_loss(self, data: np.ndarray) -> np.ndarray:
+        """Normalize TMIT data and compute percentage loss between before/after wire BPMs."""
         row_medians = np.median(data, axis=1, keepdims=True)
         ironed = data / row_medians
 

--- a/slac_measurements/tmit_loss.py
+++ b/slac_measurements/tmit_loss.py
@@ -1,6 +1,8 @@
 import gc
+from typing import Optional
 
 import numpy as np
+from pydantic import model_validator
 from slac_devices.reader import create_beampath
 from slac_devices.wire import Wire
 from slac_measurements.measurement import Measurement
@@ -16,39 +18,46 @@ class TMITLoss(Measurement):
     beampath: str
     beam_profile_device: Wire
 
-    def measure(self):
-        """Acquire TMIT data and return percentage loss as a numpy array."""
-        bpms, idx_upstream, idx_downstream = self._build_bpm_state()
-        try:
-            data = self._get_bpm_data(bpms)
-            return self._calc_tmit_loss(data, idx_upstream, idx_downstream)
-        finally:
-            del bpms
-            gc.collect()
+    bpms: Optional[dict] = None
+    idx_upstream: Optional[list] = None
+    idx_downstream: Optional[list] = None
 
-    def _build_bpm_state(self) -> tuple:
-        """Instantiate BPMs from beampath and resolve upstream/downstream indices."""
+    @model_validator(mode="after")
+    def _setup_bpms(self) -> "TMITLoss":
+        """Create BPMs at construction time so PVs can connect before measure()."""
         beampath_obj = create_beampath(self.beampath, device_types={"bpms"})
         all_bpms = beampath_obj.bpms
         if not all_bpms:
             raise LookupError("No BPMs found in beampath.")
-        bpms = dict(sorted(all_bpms.items(), key=lambda item: item[1].z_location))
+        self.bpms = dict(sorted(all_bpms.items(), key=lambda item: item[1].z_location))
 
         bpms_upstream = self.beam_profile_device.metadata.tmitloss.upstream
         bpms_downstream = self.beam_profile_device.metadata.tmitloss.downstream
-        bpm_names = list(bpms.keys())
-        idx_upstream = [bpm_names.index(name) for name in bpms_upstream if name in bpms]
-        idx_downstream = [
-            bpm_names.index(name) for name in bpms_downstream if name in bpms
+        bpm_names = list(self.bpms.keys())
+        self.idx_upstream = [
+            bpm_names.index(name) for name in bpms_upstream if name in self.bpms
         ]
+        self.idx_downstream = [
+            bpm_names.index(name) for name in bpms_downstream if name in self.bpms
+        ]
+        return self
 
-        return bpms, idx_upstream, idx_downstream
+    def measure(self):
+        """Acquire TMIT data and return percentage loss as a numpy array."""
+        try:
+            data = self._get_bpm_data()
+            return self._calc_tmit_loss(data, self.idx_upstream, self.idx_downstream)
+        finally:
+            self.bpms = None
+            self.idx_upstream = None
+            self.idx_downstream = None
+            gc.collect()
 
-    def _get_bpm_data(self, bpms: dict) -> np.ndarray:
+    def _get_bpm_data(self) -> np.ndarray:
         """Collect TMIT buffer data from all BPMs. Returns shape (n_bpms, n_samples)."""
         rows = []
         n_samples = self.buffer.n_measurements
-        for name, bpm in bpms.items():
+        for name, bpm in self.bpms.items():
             try:
                 bpm_data = collect_with_size_check(
                     bpm, "tmit_buffer", self.buffer, None

--- a/slac_measurements/tmit_loss.py
+++ b/slac_measurements/tmit_loss.py
@@ -1,6 +1,5 @@
 from typing import Optional
 
-import epics
 import numpy as np
 from pydantic import model_validator
 from slac_devices.reader import create_beampath
@@ -21,12 +20,11 @@ class TMITLoss(Measurement):
     bpms: Optional[dict] = None
     idx_upstream: Optional[list] = None
     idx_downstream: Optional[list] = None
-    _hst_pvs: Optional[list] = None
 
     @model_validator(mode="after")
     def _setup_bpms(self) -> "TMITLoss":
         """Create BPMs at construction time so PVs can connect before measure()."""
-        beampath_obj = create_beampath(self.beampath, device_types={"bpms"})
+        beampath_obj = create_beampath(self.beampath)
         all_bpms = beampath_obj.bpms
         if not all_bpms:
             raise LookupError("No BPMs found in beampath.")
@@ -41,14 +39,6 @@ class TMITLoss(Measurement):
         self.idx_downstream = [
             bpm_names.index(name) for name in bpms_downstream if name in self.bpms
         ]
-
-        self._hst_pvs = [
-            epics.PV(
-                f"{bpm.controls_information.PVs.tmit.pvname}HST{self.buffer.number}"
-            )
-            for bpm in self.bpms.values()
-        ]
-
         return self
 
     def measure(self):

--- a/slac_measurements/tmit_loss.py
+++ b/slac_measurements/tmit_loss.py
@@ -16,8 +16,8 @@ class TMITLoss(Measurement):
     beampath: str
     beam_profile_device: Wire
 
-    idx_before: Optional[list] = None
-    idx_after: Optional[list] = None
+    idx_upstream: Optional[list] = None
+    idx_downstream: Optional[list] = None
     bpms: Optional[dict] = None
 
     @model_validator(mode="after")
@@ -34,21 +34,21 @@ class TMITLoss(Measurement):
 
         def _resolve_wire_bpms() -> tuple:
             """Map wire metadata BPM names to row indices in the data array."""
-            bpms_before = self.beam_profile_device.metadata.bpms_before_wire
-            bpms_after = self.beam_profile_device.metadata.bpms_after_wire
+            bpms_upstream = self.beam_profile_device.metadata.tmitloss.upstream
+            bpms_downstream = self.beam_profile_device.metadata.tmitloss.downstream
 
             bpm_names = list(self.bpms.keys())
-            idx_before = [
-                bpm_names.index(name) for name in bpms_before if name in self.bpms
+            idx_upstream = [
+                bpm_names.index(name) for name in bpms_upstream if name in self.bpms
             ]
-            idx_after = [
-                bpm_names.index(name) for name in bpms_after if name in self.bpms
+            idx_downstream = [
+                bpm_names.index(name) for name in bpms_downstream if name in self.bpms
             ]
 
-            return idx_before, idx_after
+            return idx_upstream, idx_downstream
 
         self.bpms = _build_bpm_lookup()
-        self.idx_before, self.idx_after = _resolve_wire_bpms()
+        self.idx_upstream, self.idx_downstream = _resolve_wire_bpms()
         return self
 
     def measure(self):
@@ -69,10 +69,10 @@ class TMITLoss(Measurement):
         row_medians = np.median(data, axis=1, keepdims=True)
         ironed = data / row_medians
 
-        mean_iron_before = ironed[self.idx_before].mean(axis=0)
-        normed = ironed / mean_iron_before
+        mean_iron_upstream = ironed[self.idx_upstream].mean(axis=0)
+        normed = ironed / mean_iron_upstream
 
-        mean_before = normed[self.idx_before].mean(axis=0)
-        mean_after = normed[self.idx_after].mean(axis=0)
+        mean_upstream = normed[self.idx_upstream].mean(axis=0)
+        mean_downstream = normed[self.idx_downstream].mean(axis=0)
 
-        return (mean_before - mean_after) * 100
+        return (mean_upstream - mean_downstream) * 100

--- a/slac_measurements/tmit_loss.py
+++ b/slac_measurements/tmit_loss.py
@@ -3,7 +3,7 @@ from slac_devices.reader import create_beampath
 from slac_devices.wire import Wire
 from slac_measurements.measurement import Measurement
 from slac_measurements.utils import collect_with_size_check
-from edef import BSABuffer
+from edef import BSABuffer, EventDefinition
 from pydantic import model_validator
 from typing import Optional
 
@@ -12,7 +12,7 @@ class TMITLoss(Measurement):
     """Measures percentage beam intensity loss across a wire scanner."""
 
     name: str = "TMIT Loss"
-    buffer: BSABuffer
+    buffer: BSABuffer | EventDefinition
     beampath: str
     beam_profile_device: Wire
 

--- a/slac_measurements/tmit_loss.py
+++ b/slac_measurements/tmit_loss.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+import epics
 import numpy as np
 from pydantic import model_validator
 from slac_devices.reader import create_beampath
@@ -20,6 +21,7 @@ class TMITLoss(Measurement):
     bpms: Optional[dict] = None
     idx_upstream: Optional[list] = None
     idx_downstream: Optional[list] = None
+    _hst_pvs: Optional[list] = None
 
     @model_validator(mode="after")
     def _setup_bpms(self) -> "TMITLoss":
@@ -39,6 +41,16 @@ class TMITLoss(Measurement):
         self.idx_downstream = [
             bpm_names.index(name) for name in bpms_downstream if name in self.bpms
         ]
+
+        self._hst_pvs = [
+            epics.PV(
+                self.buffer.buffer_pv(
+                    pv=bpm.controls_information.PVs.tmit.pvname, suffix="HST"
+                )
+            )
+            for bpm in self.bpms.values()
+        ]
+
         return self
 
     def measure(self):

--- a/slac_measurements/tmit_loss.py
+++ b/slac_measurements/tmit_loss.py
@@ -24,7 +24,7 @@ class TMITLoss(Measurement):
     @model_validator(mode="after")
     def _setup_bpms(self) -> "TMITLoss":
         """Create BPMs at construction time so PVs can connect before measure()."""
-        beampath_obj = create_beampath(self.beampath)
+        beampath_obj = create_beampath(self.beampath, device_types={"bpms"})
         all_bpms = beampath_obj.bpms
         if not all_bpms:
             raise LookupError("No BPMs found in beampath.")

--- a/slac_measurements/wires/collection.py
+++ b/slac_measurements/wires/collection.py
@@ -117,8 +117,8 @@ class BaseWireMeasurementCollection(
 
             if name == "TMITLOSS":
                 return slac_measurements.tmit_loss.TMITLoss(
-                    my_buffer=self.my_buffer,
-                    my_wire=self.beam_profile_device,
+                    buffer=self.my_buffer,
+                    beam_profile_device=self.beam_profile_device,
                     beampath=self.beampath,
                     region=self.beam_profile_device.area,
                 )

--- a/slac_measurements/wires/collection.py
+++ b/slac_measurements/wires/collection.py
@@ -120,7 +120,6 @@ class BaseWireMeasurementCollection(
                     buffer=self.my_buffer,
                     beam_profile_device=self.beam_profile_device,
                     beampath=self.beampath,
-                    region=self.beam_profile_device.area,
                 )
 
             create_by_prefix = {

--- a/tests/test_tmit_loss.py
+++ b/tests/test_tmit_loss.py
@@ -1,0 +1,254 @@
+import sys
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+import numpy as np
+
+if "edef" not in sys.modules:
+    sys.modules["edef"] = MagicMock()
+
+from slac_devices.wire import Wire
+from slac_measurements.tmit_loss import TMITLoss
+
+
+def _make_mock_bpm(name, z_location):
+    """Create a mock BPM with a name and z_location."""
+    bpm = MagicMock()
+    bpm.z_location = z_location
+    bpm.name = name
+    return bpm
+
+
+def _make_mock_beampath(bpm_dict):
+    """Create a mock Beampath with a .bpms property returning bpm_dict."""
+    beampath = MagicMock()
+    beampath.bpms = bpm_dict
+    return beampath
+
+
+def _make_wire(bpms_before, bpms_after):
+    """Create a Wire instance with metadata listing before/after BPM names."""
+    metadata = MagicMock()
+    metadata.bpms_before_wire = bpms_before
+    metadata.bpms_after_wire = bpms_after
+    wire = Wire.model_construct(metadata=metadata)
+    return wire
+
+
+class TestCalcTmitLoss(TestCase):
+    """Test the TMIT loss calculation math in isolation."""
+
+    def _make_instance(self, idx_before, idx_after):
+        """Create a TMITLoss instance with given indices, bypassing validation."""
+        return TMITLoss.model_construct(
+            idx_before=idx_before,
+            idx_after=idx_after,
+        )
+
+    def test_no_loss_when_all_bpms_identical(self):
+        instance = self._make_instance([0, 1], [2, 3])
+        data = np.array(
+            [
+                [2.0, 4.0, 6.0],
+                [2.0, 4.0, 6.0],
+                [2.0, 4.0, 6.0],
+                [2.0, 4.0, 6.0],
+            ]
+        )
+
+        result = instance.calc_tmit_loss(data)
+
+        np.testing.assert_allclose(result, [0.0, 0.0, 0.0], atol=1e-10)
+
+    def test_known_loss_values(self):
+        instance = self._make_instance([0, 1], [2, 3])
+        data = np.array(
+            [
+                [2.0, 4.0],
+                [2.0, 4.0],
+                [1.0, 4.0],
+                [1.0, 4.0],
+            ]
+        )
+
+        result = instance.calc_tmit_loss(data)
+
+        # Hand-computed:
+        # row_medians = [3, 3, 2.5, 2.5]
+        # ironed = [[2/3, 4/3], [2/3, 4/3], [0.4, 1.6], [0.4, 1.6]]
+        # mean_iron_before = [2/3, 4/3]
+        # normed = [[1, 1], [1, 1], [0.6, 1.2], [0.6, 1.2]]
+        # mean_before = [1, 1], mean_after = [0.6, 1.2]
+        # loss = [40, -20]
+        np.testing.assert_allclose(result, [40.0, -20.0], atol=1e-10)
+
+    def test_uniform_fractional_loss_gives_zero(self):
+        """A constant fractional loss across all shots normalizes away."""
+        instance = self._make_instance([0, 1], [2, 3])
+        data = np.array(
+            [
+                [100.0, 200.0, 150.0],
+                [100.0, 200.0, 150.0],
+                [50.0, 100.0, 75.0],
+                [50.0, 100.0, 75.0],
+            ]
+        )
+
+        result = instance.calc_tmit_loss(data)
+
+        np.testing.assert_allclose(result, [0.0, 0.0, 0.0], atol=1e-10)
+
+
+class TestRunSetup(TestCase):
+    """Test that model validation wires up BPMs and indices correctly."""
+
+    @patch("slac_measurements.tmit_loss.create_beampath")
+    def test_bpms_sorted_by_z_location(self, mock_create_beampath):
+        bpm_a = _make_mock_bpm("BPM_A", z_location=10.0)
+        bpm_b = _make_mock_bpm("BPM_B", z_location=5.0)
+        bpm_c = _make_mock_bpm("BPM_C", z_location=20.0)
+        mock_create_beampath.return_value = _make_mock_beampath(
+            {"BPM_A": bpm_a, "BPM_B": bpm_b, "BPM_C": bpm_c}
+        )
+
+        wire = _make_wire(
+            bpms_before=["BPM_B"],
+            bpms_after=["BPM_C"],
+        )
+
+        instance = TMITLoss(
+            buffer=MagicMock(),
+            beampath="TEST",
+            beam_profile_device=wire,
+        )
+
+        self.assertEqual(list(instance.bpms.keys()), ["BPM_B", "BPM_A", "BPM_C"])
+
+    @patch("slac_measurements.tmit_loss.create_beampath")
+    def test_indices_resolve_correctly(self, mock_create_beampath):
+        bpm_a = _make_mock_bpm("BPM_A", z_location=1.0)
+        bpm_b = _make_mock_bpm("BPM_B", z_location=2.0)
+        bpm_c = _make_mock_bpm("BPM_C", z_location=3.0)
+        bpm_d = _make_mock_bpm("BPM_D", z_location=4.0)
+        mock_create_beampath.return_value = _make_mock_beampath(
+            {"BPM_A": bpm_a, "BPM_B": bpm_b, "BPM_C": bpm_c, "BPM_D": bpm_d}
+        )
+
+        wire = _make_wire(
+            bpms_before=["BPM_A", "BPM_B"],
+            bpms_after=["BPM_C", "BPM_D"],
+        )
+
+        instance = TMITLoss(
+            buffer=MagicMock(),
+            beampath="TEST",
+            beam_profile_device=wire,
+        )
+
+        self.assertEqual(instance.idx_before, [0, 1])
+        self.assertEqual(instance.idx_after, [2, 3])
+
+    @patch("slac_measurements.tmit_loss.create_beampath")
+    def test_missing_bpms_skipped(self, mock_create_beampath):
+        bpm_a = _make_mock_bpm("BPM_A", z_location=1.0)
+        bpm_b = _make_mock_bpm("BPM_B", z_location=2.0)
+        mock_create_beampath.return_value = _make_mock_beampath(
+            {"BPM_A": bpm_a, "BPM_B": bpm_b}
+        )
+
+        wire = _make_wire(
+            bpms_before=["BPM_A", "BPM_MISSING"],
+            bpms_after=["BPM_B", "BPM_GONE"],
+        )
+
+        instance = TMITLoss(
+            buffer=MagicMock(),
+            beampath="TEST",
+            beam_profile_device=wire,
+        )
+
+        self.assertEqual(instance.idx_before, [0])
+        self.assertEqual(instance.idx_after, [1])
+
+    @patch("slac_measurements.tmit_loss.create_beampath")
+    def test_empty_beampath_raises(self, mock_create_beampath):
+        mock_create_beampath.return_value = _make_mock_beampath({})
+
+        wire = _make_wire(bpms_before=[], bpms_after=[])
+
+        with self.assertRaises(LookupError):
+            TMITLoss(
+                buffer=MagicMock(),
+                beampath="TEST",
+                beam_profile_device=wire,
+            )
+
+
+class TestMeasure(TestCase):
+    """Test the full measure pipeline with mocked data collection."""
+
+    @patch("slac_measurements.tmit_loss.collect_with_size_check")
+    @patch("slac_measurements.tmit_loss.create_beampath")
+    def test_measure_returns_numpy_array(self, mock_create_beampath, mock_collect):
+        bpm_a = _make_mock_bpm("BPM_A", z_location=1.0)
+        bpm_b = _make_mock_bpm("BPM_B", z_location=2.0)
+        bpm_c = _make_mock_bpm("BPM_C", z_location=3.0)
+        bpm_d = _make_mock_bpm("BPM_D", z_location=4.0)
+        mock_create_beampath.return_value = _make_mock_beampath(
+            {"BPM_A": bpm_a, "BPM_B": bpm_b, "BPM_C": bpm_c, "BPM_D": bpm_d}
+        )
+
+        wire = _make_wire(
+            bpms_before=["BPM_A", "BPM_B"],
+            bpms_after=["BPM_C", "BPM_D"],
+        )
+
+        mock_collect.side_effect = [
+            np.array([2.0, 4.0]),
+            np.array([2.0, 4.0]),
+            np.array([2.0, 4.0]),
+            np.array([2.0, 4.0]),
+        ]
+
+        instance = TMITLoss(
+            buffer=MagicMock(),
+            beampath="TEST",
+            beam_profile_device=wire,
+        )
+
+        result = instance.measure()
+
+        self.assertIsInstance(result, np.ndarray)
+        np.testing.assert_allclose(result, [0.0, 0.0], atol=1e-10)
+
+    @patch("slac_measurements.tmit_loss.collect_with_size_check")
+    @patch("slac_measurements.tmit_loss.create_beampath")
+    def test_measure_with_loss(self, mock_create_beampath, mock_collect):
+        bpm_a = _make_mock_bpm("BPM_A", z_location=1.0)
+        bpm_b = _make_mock_bpm("BPM_B", z_location=2.0)
+        bpm_c = _make_mock_bpm("BPM_C", z_location=3.0)
+        bpm_d = _make_mock_bpm("BPM_D", z_location=4.0)
+        mock_create_beampath.return_value = _make_mock_beampath(
+            {"BPM_A": bpm_a, "BPM_B": bpm_b, "BPM_C": bpm_c, "BPM_D": bpm_d}
+        )
+
+        wire = _make_wire(
+            bpms_before=["BPM_A", "BPM_B"],
+            bpms_after=["BPM_C", "BPM_D"],
+        )
+
+        mock_collect.side_effect = [
+            np.array([2.0, 4.0]),
+            np.array([2.0, 4.0]),
+            np.array([1.0, 4.0]),
+            np.array([1.0, 4.0]),
+        ]
+
+        instance = TMITLoss(
+            buffer=MagicMock(),
+            beampath="TEST",
+            beam_profile_device=wire,
+        )
+
+        result = instance.measure()
+
+        np.testing.assert_allclose(result, [40.0, -20.0], atol=1e-10)

--- a/tests/test_tmit_loss.py
+++ b/tests/test_tmit_loss.py
@@ -26,10 +26,12 @@ def _make_mock_beampath(bpm_dict):
 
 
 def _make_wire(bpms_before, bpms_after):
-    """Create a Wire instance with metadata listing before/after BPM names."""
+    """Create a Wire instance with metadata listing upstream/downstream BPM names."""
+    tmitloss = MagicMock()
+    tmitloss.upstream = bpms_before
+    tmitloss.downstream = bpms_after
     metadata = MagicMock()
-    metadata.bpms_before_wire = bpms_before
-    metadata.bpms_after_wire = bpms_after
+    metadata.tmitloss = tmitloss
     wire = Wire.model_construct(metadata=metadata)
     return wire
 


### PR DESCRIPTION
This pull request refactors the `TMITLoss` measurement class to simplify its logic, improve maintainability, and remove unnecessary dependencies. The changes include replacing pandas DataFrame operations with numpy arrays, consolidating and clarifying the setup and calculation logic, and adding comprehensive unit tests for the new implementation. Additionally, the dependency on `pandas` has been removed from the project.

**Refactor and simplification of TMITLoss logic:**

* The `TMITLoss` class in `slac_measurements/tmit_loss.py` has been rewritten to use numpy arrays instead of pandas DataFrames, greatly simplifying data handling and improving performance. The setup and calculation logic was consolidated, with redundant and legacy methods removed. The class now constructs BPM lookup tables and resolves before/after indices in a more robust and maintainable way, based on the `slac-tools` Beampath object.
* The interface for instantiating `TMITLoss` in `slac_measurements/wires/collection.py` was updated to match the new attribute names and remove the unused `region` parameter.

**Dependency management:**

* The dependency on `pandas` was removed from `pyproject.toml`, as it is no longer needed for TMIT loss calculations.

**Testing improvements:**

* A comprehensive new test suite for the `TMITLoss` class was added in `tests/test_tmit_loss.py`, covering calculation correctness, edge cases, setup logic, and the full measurement pipeline with mocks. This ensures the new implementation is robust and correct.