### PR TITLE
Refactor TMITLoss class, update dependencies, and add unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
     "pyyaml",
     "pydantic",
     "h5py",
-    "pandas",
     "scikit-image",
     "torch",
     "slac-devices @ git+https://github.com/slaclab/slac-devices.git@main"

--- a/slac_measurements/tmit_loss.py
+++ b/slac_measurements/tmit_loss.py
@@ -24,7 +24,7 @@ class TMITLoss(Measurement):
 
     @model_validator(mode="after")
     def _setup_bpms(self) -> "TMITLoss":
-        """Create BPMs at construction time so PVs can connect before measure()."""
+        """Load BPMs from beampath and resolve upstream/downstream indices."""
         self._beampath_obj = create_beampath(self.beampath, device_types={"bpms"})
         all_bpms = self._beampath_obj.bpms
         if not all_bpms:
@@ -71,7 +71,7 @@ class TMITLoss(Measurement):
     def _calc_tmit_loss(
         data: np.ndarray, idx_upstream: list, idx_downstream: list
     ) -> np.ndarray:
-        """Normalize TMIT data and compute percentage loss between before/after wire BPMs."""
+        """Normalize TMIT data and compute percentage loss between upstream/downstream BPMs."""
         row_medians = np.nanmedian(data, axis=1, keepdims=True)
         ironed = data / row_medians
 

--- a/slac_measurements/tmit_loss.py
+++ b/slac_measurements/tmit_loss.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
-import epics
 import numpy as np
 from pydantic import model_validator
+from slac_devices.beampath import Beampath
 from slac_devices.reader import create_beampath
 from slac_devices.wire import Wire
 from slac_measurements.measurement import Measurement
@@ -17,6 +17,7 @@ class TMITLoss(Measurement):
     beampath: str
     beam_profile_device: Wire
 
+    _beampath_obj: Optional[Beampath] = None
     bpms: Optional[dict] = None
     idx_upstream: Optional[list] = None
     idx_downstream: Optional[list] = None
@@ -24,8 +25,8 @@ class TMITLoss(Measurement):
     @model_validator(mode="after")
     def _setup_bpms(self) -> "TMITLoss":
         """Create BPMs at construction time so PVs can connect before measure()."""
-        beampath_obj = create_beampath(self.beampath, device_types={"bpms"})
-        all_bpms = beampath_obj.bpms
+        self._beampath_obj = create_beampath(self.beampath, device_types={"bpms"})
+        all_bpms = self._beampath_obj.bpms
         if not all_bpms:
             raise LookupError("No BPMs found in beampath.")
         self.bpms = dict(sorted(all_bpms.items(), key=lambda item: item[1].z_location))
@@ -48,27 +49,22 @@ class TMITLoss(Measurement):
 
     def _get_bpm_data(self) -> np.ndarray:
         """Collect TMIT buffer data from all BPMs. Returns shape (n_bpms, n_samples)."""
-        pv_names = [
-            f"{bpm.controls_information.control_name}:TMIT"
-            for bpm in self.bpms.values()
-        ]
-        hst_pvs = [f"{pv}HST{self.buffer.number}" for pv in pv_names]
-        results = epics.caget_many(hst_pvs)
-
         n_samples = self.buffer.n_measurements
+        bpm_names = list(self.bpms.keys())
+
+        all_data = {}
+        for area in self._beampath_obj.areas.values():
+            if area.bpm_collection:
+                all_data.update(area.bpm_collection.get_buffer_data(self.buffer))
+
         rows = []
-        for name, data in zip(self.bpms.keys(), results):
-            if data is None or len(data) < n_samples:
-                if data is not None:
-                    print(
-                        f"Skipping BPM {name}: incomplete data ({len(data)}/{n_samples})"
-                    )
-                else:
-                    print(f"Skipping BPM {name}: no buffer data")
-                row = np.full(n_samples, np.nan)
+        for name in bpm_names:
+            data = all_data.get(name)
+            if data is None:
+                print(f"Skipping BPM {name}: no buffer data")
+                rows.append(np.full(n_samples, np.nan))
             else:
-                row = np.asarray(data[:n_samples], dtype=float)
-            rows.append(row)
+                rows.append(np.asarray(data, dtype=float))
         return np.array(rows)
 
     @staticmethod

--- a/slac_measurements/tmit_loss.py
+++ b/slac_measurements/tmit_loss.py
@@ -1,253 +1,88 @@
-from slac_devices.reader import create_bpm
-from slac_measurements.measurement import Measurement
-from slac_measurements.utils import collect_with_size_check
-import pandas as pd
-from edef import BSABuffer
-from slac_devices.wire import Wire
-from pydantic import model_validator
 from typing import Optional
+
+import epics
+import numpy as np
+from pydantic import model_validator
+from slac_devices.reader import create_beampath
+from slac_devices.wire import Wire
+from slac_measurements.measurement import Measurement
+from edef import BSABuffer, EventDefinition
 
 
 class TMITLoss(Measurement):
-    name: str = "TMIT Loss Beam Size"
-    my_buffer: BSABuffer
+    """Measures percentage beam intensity loss across a wire scanner."""
+
+    name: str = "TMIT Loss"
+    buffer: BSABuffer | EventDefinition
     beampath: str
-    region: str
     beam_profile_device: Wire
 
-    # Extra fields to be set after validation
-    idx_before: Optional[list] = None
-    idx_after: Optional[list] = None
     bpms: Optional[dict] = None
+    idx_upstream: Optional[list] = None
+    idx_downstream: Optional[list] = None
 
     @model_validator(mode="after")
-    def run_setup(self) -> "TMITLoss":
-        bpms_elements, bpms_devices = self.find_bpms()
-        self.idx_before, self.idx_after = self.get_bpm_idx(bpms_devices)
-        self.bpms = self.create_bpms(bpms_elements)
+    def _setup_bpms(self) -> "TMITLoss":
+        """Create BPMs at construction time so PVs can connect before measure()."""
+        beampath_obj = create_beampath(self.beampath, device_types={"bpms"})
+        all_bpms = beampath_obj.bpms
+        if not all_bpms:
+            raise LookupError("No BPMs found in beampath.")
+        self.bpms = dict(sorted(all_bpms.items(), key=lambda item: item[1].z_location))
+
+        bpms_upstream = self.beam_profile_device.metadata.tmitloss.upstream
+        bpms_downstream = self.beam_profile_device.metadata.tmitloss.downstream
+        bpm_names = list(self.bpms.keys())
+        self.idx_upstream = [
+            bpm_names.index(name) for name in bpms_upstream if name in self.bpms
+        ]
+        self.idx_downstream = [
+            bpm_names.index(name) for name in bpms_downstream if name in self.bpms
+        ]
         return self
 
     def measure(self):
-        """
-        Compute the TMIT loss for a given beam path and region.
+        """Acquire TMIT data and return percentage loss as a numpy array."""
+        data = self._get_bpm_data()
+        return self._calc_tmit_loss(data, self.idx_upstream, self.idx_downstream)
 
-        This method orchestrates the full process of acquiring BPM data,
-        normalizing it, and calculating TMIT loss by:
-        - Reserving a data buffer.
-        - Retrieving BPM elements and device names.
-        - Identifying BPM indices before and after the wire.
-        - Creating BPM objects.
-        - Collecting TMIT data.
-        - Computing the TMIT loss.
+    def _get_bpm_data(self) -> np.ndarray:
+        """Collect TMIT buffer data from all BPMs. Returns shape (n_bpms, n_samples)."""
+        pv_names = [
+            f"{bpm.controls_information.control_name}:TMIT"
+            for bpm in self.bpms.values()
+        ]
+        hst_pvs = [f"{pv}HST{self.buffer.number}" for pv in pv_names]
+        results = epics.caget_many(hst_pvs)
 
-        Args:
-            beampath (str): The beam path used to filter BPM elements.
-            region (str): The region of interest, which determines the BPMs
-                          used for before/after wire measurements.
+        n_samples = self.buffer.n_measurements
+        rows = []
+        for name, data in zip(self.bpms.keys(), results):
+            if data is None or len(data) < n_samples:
+                if data is not None:
+                    print(
+                        f"Skipping BPM {name}: incomplete data ({len(data)}/{n_samples})"
+                    )
+                else:
+                    print(f"Skipping BPM {name}: no buffer data")
+                row = np.full(n_samples, np.nan)
+            else:
+                row = np.asarray(data[:n_samples], dtype=float)
+            rows.append(row)
+        return np.array(rows)
 
-        Returns:
-            pd.Series: A Series representing the percentage TMIT loss for each
-                       time sample.
-        """
-        # Retrieve data from BSA buffer
-        data = self.get_bpm_data()
+    @staticmethod
+    def _calc_tmit_loss(
+        data: np.ndarray, idx_upstream: list, idx_downstream: list
+    ) -> np.ndarray:
+        """Normalize TMIT data and compute percentage loss between before/after wire BPMs."""
+        row_medians = np.nanmedian(data, axis=1, keepdims=True)
+        ironed = data / row_medians
 
-        # Calculate TMIT Loss
-        tmit_loss_pd = self.calc_tmit_loss(data)
-        tmit_loss = tmit_loss_pd.to_numpy()
-        return tmit_loss
+        mean_iron_upstream = np.nanmean(ironed[idx_upstream], axis=0)
+        normed = ironed / mean_iron_upstream
 
-    def find_bpms(self):
-        """
-        Retrieve BPM elements and their corresponding EPICS names for a
-        given beam path.
+        mean_upstream = np.nanmean(normed[idx_upstream], axis=0)
+        mean_downstream = np.nanmean(normed[idx_downstream], axis=0)
 
-        This method queries BPM elements and devices using the `meme.names`
-        module.  It extracts the area from each BPM device name and replaces
-        any area containing "BPN" with "BYP" for proper YAML file lookup.
-
-        Args:
-            beampath (str): The beam path tag used to filter BPM elements
-            and devices.
-
-        Returns:
-            tuple: A tuple containing:
-                - pd.DataFrame: A DataFrame with BPM elements and their
-                                corresponding areas.
-                - list: A list of BPM device names.
-        """
-        import meme.names
-
-        # List of BPM MAD names based on beampath
-        bpms_elements = meme.names.list_elements(
-            "BPMS:%TMIT", tag=self.beampath, sort_by="z"
-        )
-
-        # List of BPM EPICS names based on beampath
-        bpms_devices = meme.names.list_devices(
-            "BPMS:%TMIT", tag=self.beampath, sort_by="z"
-        )
-
-        # Make Dataframe with two columns: First is the Element (MAD) name
-        # Second column is the area
-        areas_bpn = [device.split(":")[1] for device in bpms_devices]
-        # If EPICS name uses "BPN" for area, instead use "BYP"
-        areas = ["BYP" if "BPN" in item else item for item in areas_bpn]
-        bpms_elements = pd.DataFrame({"Element": bpms_elements, "Area": areas})
-        return bpms_elements, bpms_devices
-
-    def create_bpms(self, bpms_elements):
-        """
-        Create BPM device objects for a given set of BPM elements.
-
-        This method iterates through a DataFrame of BPM elements
-        and their corresponding areas, creating BPM objects
-        using the `create_bpm` function.
-
-        Args:
-            bpms_elements (pd.DataFrame): A DataFrame containing BPM
-                                          element names and their
-                                          associated areas. Must
-                                          have columns:
-                                          - 'Element' (str): The BPM
-                                            element name.
-                                          - 'Area' (str): The area
-                                            associated with the BPM.
-
-        Returns:
-            dict: A dictionary where the keys are BPM element
-            names and the values are the corresponding BPM
-            objects created using `create_bpm`.
-        """
-        bpm_obj_dict = {}
-
-        # Iterate through Dataframe of Elements and Areas
-        for _, row in bpms_elements.iterrows():
-            element = row["Element"]
-            area = row["Area"]
-
-            # Create an lcls-tools BPM object and append to dictionary
-            bpm = create_bpm(name=element, area=area)
-            if bpm is not None:
-                bpm_obj_dict[element] = bpm
-
-        if bpm_obj_dict:
-            return bpm_obj_dict
-        else:
-            raise LookupError("No BPM objects could be created.")
-
-    def get_bpm_data(self):
-        """
-        Retrieve TMIT buffer data for a set of BPMs.
-
-        This method iterates through a dictionary of BPM objects and attempts
-        to fetch their TMIT buffer data using a specified buffer. If data
-        retrieval fails for a BPM, it is assigned a `None` value.
-
-        Args:
-            bpm_obj_dict (dict): A dictionary where keys are BPM element
-                                 names (str) and values are BPM objects.
-            my_buffer (BSABuffer): The buffer used to retrieve TMIT data for
-                                 each BPM.
-
-        Returns:
-            pd.DataFrame: A transposed DataFrame where:
-                          - Rows correspond to BPM elements.
-                          - Columns contain the retrieved TMIT buffer data.
-        """
-        data = {}
-
-        for element, bpm in self.bpms.items():
-            bpm_data = collect_with_size_check(
-                bpm,
-                "tmit_buffer",
-                self.my_buffer,
-                None,
-            )
-            data[element] = bpm_data
-
-        df = pd.DataFrame(data)
-        return df.T
-
-    def get_bpm_idx(self, bpms_devices):
-        """
-        Retrieve the index positions of BPMs before and after the wire for a
-        given region.
-
-        This method selects predefined BPMs based on the specified region and
-        finds their corresponding indices in `bpms_devices`.
-
-        Args:
-            region (str): The region of interest. Must be one of:
-                          - "HTR", "DIAG0", "COL1", "EMIT2", "BYP",
-                            "SPD", "LTUS".
-            bpms_devices (list): A list of BPM device names.
-
-        Returns:
-            tuple: A tuple containing:
-                - list: Indices of BPMs located **before** the wire.
-                - list: Indices of BPMs located **after** the wire.
-        """
-        # Define valid regions
-        tmit_regions = {"HTR", "DIAG0", "COL1", "EMIT2", "DOG", "BYP", "SPD", "LTUS"}
-        if self.region not in tmit_regions:
-            valid_regions_str = ", ".join(sorted(tmit_regions))
-            raise ValueError(
-                f"Invalid region '{self.region}'. Must be one of {valid_regions_str}."
-            )
-
-        bpms_before_wire = self.beam_profile_device.metadata.bpms_before_wire
-        bpms_after_wire = self.beam_profile_device.metadata.bpms_after_wire
-
-        # Create a lookup dictionary for index mapping
-        idx_map = {value: idx for idx, value in enumerate(bpms_devices)}
-
-        # Find indices of BPMs before and after the wire
-        idx_before = [idx_map[item] for item in bpms_before_wire if item in idx_map]
-        idx_after = [idx_map[item] for item in bpms_after_wire if item in idx_map]
-
-        return idx_before, idx_after
-
-    def calc_tmit_loss(self, df):
-        """
-        Calculate the TMIT loss.
-
-        This method normalizes the TMIT data by computing row-wise medians,
-        then standardizes it relative to BPMs before a wire. The loss is
-        computed as the percentage change in mean TMIT values before and
-        after the wire.
-
-        Args:
-            df (pd.DataFrame): A DataFrame containing TMIT values, where
-                               rows correspond to BPMs and columns to
-                               time samples.
-            idx_before (list): List of row indices corresponding to BPMs
-                               before the wire.
-            idx_after (list): List of row indices corresponding to BPMs
-                              after the wire.
-
-        Returns:
-            pd.Series: A Series representing the percentage TMIT loss for each
-                       time sample.
-        """
-        # Compute row-wise medians and normalize the DataFrame
-        row_medians = df.median(axis=1)
-        df_ironed = df.div(row_medians, axis=0)
-
-        # Compute mean ironed TMIT for BPMs before the wire
-        ironed_before = df_ironed.iloc[self.idx_before, :]
-        mean_iron_before = ironed_before.mean()
-
-        # Normalize by mean TMIT before the wire
-        df_normed = df_ironed.div(mean_iron_before, axis=1)
-
-        # Compute mean ratios before and after the wire
-        normed_before = df_normed.iloc[self.idx_before]
-        normed_after = df_normed.iloc[self.idx_after]
-
-        mean_before = normed_before.mean()
-        mean_after = normed_after.mean()
-
-        # Compute TMIT Loss percentage
-        tmit_loss = (mean_before - mean_after) * 100
-        return tmit_loss
+        return (mean_upstream - mean_downstream) * 100

--- a/slac_measurements/wires/collection.py
+++ b/slac_measurements/wires/collection.py
@@ -117,10 +117,9 @@ class BaseWireMeasurementCollection(
 
             if name == "TMITLOSS":
                 return slac_measurements.tmit_loss.TMITLoss(
-                    my_buffer=self.my_buffer,
-                    my_wire=self.beam_profile_device,
+                    buffer=self.my_buffer,
+                    beam_profile_device=self.beam_profile_device,
                     beampath=self.beampath,
-                    region=self.beam_profile_device.area,
                 )
 
             create_by_prefix = {

--- a/tests/test_tmit_loss.py
+++ b/tests/test_tmit_loss.py
@@ -19,10 +19,15 @@ def _make_mock_bpm(name, z_location, control_name):
     return bpm
 
 
-def _make_mock_beampath(bpm_dict):
-    """Create a mock Beampath with a .bpms property returning bpm_dict."""
+def _make_mock_beampath(bpm_dict, buffer_data=None):
+    """Create a mock Beampath with .bpms and .areas for get_buffer_data."""
     beampath = MagicMock()
     beampath.bpms = bpm_dict
+
+    area = MagicMock()
+    area.bpm_collection.get_buffer_data.return_value = buffer_data or {}
+    beampath.areas.values.return_value = [area]
+
     return beampath
 
 
@@ -179,15 +184,23 @@ class TestRunSetup(TestCase):
 class TestMeasure(TestCase):
     """Test the full measure pipeline with mocked data collection."""
 
-    @patch("slac_measurements.tmit_loss.epics.caget_many")
     @patch("slac_measurements.tmit_loss.create_beampath")
-    def test_measure_returns_numpy_array(self, mock_create_beampath, mock_caget_many):
+    def test_measure_returns_numpy_array(self, mock_create_beampath):
         bpm_a = _make_mock_bpm("BPM_A", z_location=1.0, control_name="BPMS:A")
         bpm_b = _make_mock_bpm("BPM_B", z_location=2.0, control_name="BPMS:B")
         bpm_c = _make_mock_bpm("BPM_C", z_location=3.0, control_name="BPMS:C")
         bpm_d = _make_mock_bpm("BPM_D", z_location=4.0, control_name="BPMS:D")
+
+        buffer_data = {
+            "BPM_A": np.array([2.0, 4.0]),
+            "BPM_B": np.array([2.0, 4.0]),
+            "BPM_C": np.array([2.0, 4.0]),
+            "BPM_D": np.array([2.0, 4.0]),
+        }
+
         mock_create_beampath.return_value = _make_mock_beampath(
-            {"BPM_A": bpm_a, "BPM_B": bpm_b, "BPM_C": bpm_c, "BPM_D": bpm_d}
+            {"BPM_A": bpm_a, "BPM_B": bpm_b, "BPM_C": bpm_c, "BPM_D": bpm_d},
+            buffer_data=buffer_data,
         )
 
         wire = _make_wire(
@@ -196,15 +209,7 @@ class TestMeasure(TestCase):
         )
 
         mock_buffer = MagicMock()
-        mock_buffer.number = 3
         mock_buffer.n_measurements = 2
-
-        mock_caget_many.return_value = [
-            np.array([2.0, 4.0]),
-            np.array([2.0, 4.0]),
-            np.array([2.0, 4.0]),
-            np.array([2.0, 4.0]),
-        ]
 
         instance = TMITLoss(
             buffer=mock_buffer,
@@ -217,15 +222,23 @@ class TestMeasure(TestCase):
         self.assertIsInstance(result, np.ndarray)
         np.testing.assert_allclose(result, [0.0, 0.0], atol=1e-10)
 
-    @patch("slac_measurements.tmit_loss.epics.caget_many")
     @patch("slac_measurements.tmit_loss.create_beampath")
-    def test_measure_with_loss(self, mock_create_beampath, mock_caget_many):
+    def test_measure_with_loss(self, mock_create_beampath):
         bpm_a = _make_mock_bpm("BPM_A", z_location=1.0, control_name="BPMS:A")
         bpm_b = _make_mock_bpm("BPM_B", z_location=2.0, control_name="BPMS:B")
         bpm_c = _make_mock_bpm("BPM_C", z_location=3.0, control_name="BPMS:C")
         bpm_d = _make_mock_bpm("BPM_D", z_location=4.0, control_name="BPMS:D")
+
+        buffer_data = {
+            "BPM_A": np.array([2.0, 4.0]),
+            "BPM_B": np.array([2.0, 4.0]),
+            "BPM_C": np.array([1.0, 4.0]),
+            "BPM_D": np.array([1.0, 4.0]),
+        }
+
         mock_create_beampath.return_value = _make_mock_beampath(
-            {"BPM_A": bpm_a, "BPM_B": bpm_b, "BPM_C": bpm_c, "BPM_D": bpm_d}
+            {"BPM_A": bpm_a, "BPM_B": bpm_b, "BPM_C": bpm_c, "BPM_D": bpm_d},
+            buffer_data=buffer_data,
         )
 
         wire = _make_wire(
@@ -234,15 +247,7 @@ class TestMeasure(TestCase):
         )
 
         mock_buffer = MagicMock()
-        mock_buffer.number = 3
         mock_buffer.n_measurements = 2
-
-        mock_caget_many.return_value = [
-            np.array([2.0, 4.0]),
-            np.array([2.0, 4.0]),
-            np.array([1.0, 4.0]),
-            np.array([1.0, 4.0]),
-        ]
 
         instance = TMITLoss(
             buffer=mock_buffer,

--- a/tests/test_tmit_loss.py
+++ b/tests/test_tmit_loss.py
@@ -10,11 +10,12 @@ from slac_devices.wire import Wire
 from slac_measurements.tmit_loss import TMITLoss
 
 
-def _make_mock_bpm(name, z_location):
-    """Create a mock BPM with a name and z_location."""
+def _make_mock_bpm(name, z_location, control_name):
+    """Create a mock BPM with a name, z_location, and control_name."""
     bpm = MagicMock()
     bpm.z_location = z_location
     bpm.name = name
+    bpm.controls_information.control_name = control_name
     return bpm
 
 
@@ -39,15 +40,7 @@ def _make_wire(bpms_before, bpms_after):
 class TestCalcTmitLoss(TestCase):
     """Test the TMIT loss calculation math in isolation."""
 
-    def _make_instance(self, idx_before, idx_after):
-        """Create a TMITLoss instance with given indices, bypassing validation."""
-        return TMITLoss.model_construct(
-            idx_before=idx_before,
-            idx_after=idx_after,
-        )
-
     def test_no_loss_when_all_bpms_identical(self):
-        instance = self._make_instance([0, 1], [2, 3])
         data = np.array(
             [
                 [2.0, 4.0, 6.0],
@@ -57,12 +50,11 @@ class TestCalcTmitLoss(TestCase):
             ]
         )
 
-        result = instance.calc_tmit_loss(data)
+        result = TMITLoss._calc_tmit_loss(data, [0, 1], [2, 3])
 
         np.testing.assert_allclose(result, [0.0, 0.0, 0.0], atol=1e-10)
 
     def test_known_loss_values(self):
-        instance = self._make_instance([0, 1], [2, 3])
         data = np.array(
             [
                 [2.0, 4.0],
@@ -72,7 +64,7 @@ class TestCalcTmitLoss(TestCase):
             ]
         )
 
-        result = instance.calc_tmit_loss(data)
+        result = TMITLoss._calc_tmit_loss(data, [0, 1], [2, 3])
 
         # Hand-computed:
         # row_medians = [3, 3, 2.5, 2.5]
@@ -85,7 +77,6 @@ class TestCalcTmitLoss(TestCase):
 
     def test_uniform_fractional_loss_gives_zero(self):
         """A constant fractional loss across all shots normalizes away."""
-        instance = self._make_instance([0, 1], [2, 3])
         data = np.array(
             [
                 [100.0, 200.0, 150.0],
@@ -95,7 +86,7 @@ class TestCalcTmitLoss(TestCase):
             ]
         )
 
-        result = instance.calc_tmit_loss(data)
+        result = TMITLoss._calc_tmit_loss(data, [0, 1], [2, 3])
 
         np.testing.assert_allclose(result, [0.0, 0.0, 0.0], atol=1e-10)
 
@@ -105,9 +96,9 @@ class TestRunSetup(TestCase):
 
     @patch("slac_measurements.tmit_loss.create_beampath")
     def test_bpms_sorted_by_z_location(self, mock_create_beampath):
-        bpm_a = _make_mock_bpm("BPM_A", z_location=10.0)
-        bpm_b = _make_mock_bpm("BPM_B", z_location=5.0)
-        bpm_c = _make_mock_bpm("BPM_C", z_location=20.0)
+        bpm_a = _make_mock_bpm("BPM_A", z_location=10.0, control_name="BPMS:A")
+        bpm_b = _make_mock_bpm("BPM_B", z_location=5.0, control_name="BPMS:B")
+        bpm_c = _make_mock_bpm("BPM_C", z_location=20.0, control_name="BPMS:C")
         mock_create_beampath.return_value = _make_mock_beampath(
             {"BPM_A": bpm_a, "BPM_B": bpm_b, "BPM_C": bpm_c}
         )
@@ -127,10 +118,10 @@ class TestRunSetup(TestCase):
 
     @patch("slac_measurements.tmit_loss.create_beampath")
     def test_indices_resolve_correctly(self, mock_create_beampath):
-        bpm_a = _make_mock_bpm("BPM_A", z_location=1.0)
-        bpm_b = _make_mock_bpm("BPM_B", z_location=2.0)
-        bpm_c = _make_mock_bpm("BPM_C", z_location=3.0)
-        bpm_d = _make_mock_bpm("BPM_D", z_location=4.0)
+        bpm_a = _make_mock_bpm("BPM_A", z_location=1.0, control_name="BPMS:A")
+        bpm_b = _make_mock_bpm("BPM_B", z_location=2.0, control_name="BPMS:B")
+        bpm_c = _make_mock_bpm("BPM_C", z_location=3.0, control_name="BPMS:C")
+        bpm_d = _make_mock_bpm("BPM_D", z_location=4.0, control_name="BPMS:D")
         mock_create_beampath.return_value = _make_mock_beampath(
             {"BPM_A": bpm_a, "BPM_B": bpm_b, "BPM_C": bpm_c, "BPM_D": bpm_d}
         )
@@ -146,13 +137,13 @@ class TestRunSetup(TestCase):
             beam_profile_device=wire,
         )
 
-        self.assertEqual(instance.idx_before, [0, 1])
-        self.assertEqual(instance.idx_after, [2, 3])
+        self.assertEqual(instance.idx_upstream, [0, 1])
+        self.assertEqual(instance.idx_downstream, [2, 3])
 
     @patch("slac_measurements.tmit_loss.create_beampath")
     def test_missing_bpms_skipped(self, mock_create_beampath):
-        bpm_a = _make_mock_bpm("BPM_A", z_location=1.0)
-        bpm_b = _make_mock_bpm("BPM_B", z_location=2.0)
+        bpm_a = _make_mock_bpm("BPM_A", z_location=1.0, control_name="BPMS:A")
+        bpm_b = _make_mock_bpm("BPM_B", z_location=2.0, control_name="BPMS:B")
         mock_create_beampath.return_value = _make_mock_beampath(
             {"BPM_A": bpm_a, "BPM_B": bpm_b}
         )
@@ -168,8 +159,8 @@ class TestRunSetup(TestCase):
             beam_profile_device=wire,
         )
 
-        self.assertEqual(instance.idx_before, [0])
-        self.assertEqual(instance.idx_after, [1])
+        self.assertEqual(instance.idx_upstream, [0])
+        self.assertEqual(instance.idx_downstream, [1])
 
     @patch("slac_measurements.tmit_loss.create_beampath")
     def test_empty_beampath_raises(self, mock_create_beampath):
@@ -188,13 +179,13 @@ class TestRunSetup(TestCase):
 class TestMeasure(TestCase):
     """Test the full measure pipeline with mocked data collection."""
 
-    @patch("slac_measurements.tmit_loss.collect_with_size_check")
+    @patch("slac_measurements.tmit_loss.epics.caget_many")
     @patch("slac_measurements.tmit_loss.create_beampath")
-    def test_measure_returns_numpy_array(self, mock_create_beampath, mock_collect):
-        bpm_a = _make_mock_bpm("BPM_A", z_location=1.0)
-        bpm_b = _make_mock_bpm("BPM_B", z_location=2.0)
-        bpm_c = _make_mock_bpm("BPM_C", z_location=3.0)
-        bpm_d = _make_mock_bpm("BPM_D", z_location=4.0)
+    def test_measure_returns_numpy_array(self, mock_create_beampath, mock_caget_many):
+        bpm_a = _make_mock_bpm("BPM_A", z_location=1.0, control_name="BPMS:A")
+        bpm_b = _make_mock_bpm("BPM_B", z_location=2.0, control_name="BPMS:B")
+        bpm_c = _make_mock_bpm("BPM_C", z_location=3.0, control_name="BPMS:C")
+        bpm_d = _make_mock_bpm("BPM_D", z_location=4.0, control_name="BPMS:D")
         mock_create_beampath.return_value = _make_mock_beampath(
             {"BPM_A": bpm_a, "BPM_B": bpm_b, "BPM_C": bpm_c, "BPM_D": bpm_d}
         )
@@ -204,7 +195,11 @@ class TestMeasure(TestCase):
             bpms_after=["BPM_C", "BPM_D"],
         )
 
-        mock_collect.side_effect = [
+        mock_buffer = MagicMock()
+        mock_buffer.number = 3
+        mock_buffer.n_measurements = 2
+
+        mock_caget_many.return_value = [
             np.array([2.0, 4.0]),
             np.array([2.0, 4.0]),
             np.array([2.0, 4.0]),
@@ -212,7 +207,7 @@ class TestMeasure(TestCase):
         ]
 
         instance = TMITLoss(
-            buffer=MagicMock(),
+            buffer=mock_buffer,
             beampath="TEST",
             beam_profile_device=wire,
         )
@@ -222,13 +217,13 @@ class TestMeasure(TestCase):
         self.assertIsInstance(result, np.ndarray)
         np.testing.assert_allclose(result, [0.0, 0.0], atol=1e-10)
 
-    @patch("slac_measurements.tmit_loss.collect_with_size_check")
+    @patch("slac_measurements.tmit_loss.epics.caget_many")
     @patch("slac_measurements.tmit_loss.create_beampath")
-    def test_measure_with_loss(self, mock_create_beampath, mock_collect):
-        bpm_a = _make_mock_bpm("BPM_A", z_location=1.0)
-        bpm_b = _make_mock_bpm("BPM_B", z_location=2.0)
-        bpm_c = _make_mock_bpm("BPM_C", z_location=3.0)
-        bpm_d = _make_mock_bpm("BPM_D", z_location=4.0)
+    def test_measure_with_loss(self, mock_create_beampath, mock_caget_many):
+        bpm_a = _make_mock_bpm("BPM_A", z_location=1.0, control_name="BPMS:A")
+        bpm_b = _make_mock_bpm("BPM_B", z_location=2.0, control_name="BPMS:B")
+        bpm_c = _make_mock_bpm("BPM_C", z_location=3.0, control_name="BPMS:C")
+        bpm_d = _make_mock_bpm("BPM_D", z_location=4.0, control_name="BPMS:D")
         mock_create_beampath.return_value = _make_mock_beampath(
             {"BPM_A": bpm_a, "BPM_B": bpm_b, "BPM_C": bpm_c, "BPM_D": bpm_d}
         )
@@ -238,7 +233,11 @@ class TestMeasure(TestCase):
             bpms_after=["BPM_C", "BPM_D"],
         )
 
-        mock_collect.side_effect = [
+        mock_buffer = MagicMock()
+        mock_buffer.number = 3
+        mock_buffer.n_measurements = 2
+
+        mock_caget_many.return_value = [
             np.array([2.0, 4.0]),
             np.array([2.0, 4.0]),
             np.array([1.0, 4.0]),
@@ -246,7 +245,7 @@ class TestMeasure(TestCase):
         ]
 
         instance = TMITLoss(
-            buffer=MagicMock(),
+            buffer=mock_buffer,
             beampath="TEST",
             beam_profile_device=wire,
         )

--- a/tests/test_tmit_loss.py
+++ b/tests/test_tmit_loss.py
@@ -1,0 +1,256 @@
+import sys
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+import numpy as np
+
+if "edef" not in sys.modules:
+    sys.modules["edef"] = MagicMock()
+
+from slac_devices.wire import Wire
+from slac_measurements.tmit_loss import TMITLoss
+
+
+def _make_mock_bpm(name, z_location):
+    """Create a mock BPM with a name and z_location."""
+    bpm = MagicMock()
+    bpm.z_location = z_location
+    bpm.name = name
+    return bpm
+
+
+def _make_mock_beampath(bpm_dict):
+    """Create a mock Beampath with a .bpms property returning bpm_dict."""
+    beampath = MagicMock()
+    beampath.bpms = bpm_dict
+    return beampath
+
+
+def _make_wire(bpms_before, bpms_after):
+    """Create a Wire instance with metadata listing upstream/downstream BPM names."""
+    tmitloss = MagicMock()
+    tmitloss.upstream = bpms_before
+    tmitloss.downstream = bpms_after
+    metadata = MagicMock()
+    metadata.tmitloss = tmitloss
+    wire = Wire.model_construct(metadata=metadata)
+    return wire
+
+
+class TestCalcTmitLoss(TestCase):
+    """Test the TMIT loss calculation math in isolation."""
+
+    def _make_instance(self, idx_before, idx_after):
+        """Create a TMITLoss instance with given indices, bypassing validation."""
+        return TMITLoss.model_construct(
+            idx_before=idx_before,
+            idx_after=idx_after,
+        )
+
+    def test_no_loss_when_all_bpms_identical(self):
+        instance = self._make_instance([0, 1], [2, 3])
+        data = np.array(
+            [
+                [2.0, 4.0, 6.0],
+                [2.0, 4.0, 6.0],
+                [2.0, 4.0, 6.0],
+                [2.0, 4.0, 6.0],
+            ]
+        )
+
+        result = instance.calc_tmit_loss(data)
+
+        np.testing.assert_allclose(result, [0.0, 0.0, 0.0], atol=1e-10)
+
+    def test_known_loss_values(self):
+        instance = self._make_instance([0, 1], [2, 3])
+        data = np.array(
+            [
+                [2.0, 4.0],
+                [2.0, 4.0],
+                [1.0, 4.0],
+                [1.0, 4.0],
+            ]
+        )
+
+        result = instance.calc_tmit_loss(data)
+
+        # Hand-computed:
+        # row_medians = [3, 3, 2.5, 2.5]
+        # ironed = [[2/3, 4/3], [2/3, 4/3], [0.4, 1.6], [0.4, 1.6]]
+        # mean_iron_before = [2/3, 4/3]
+        # normed = [[1, 1], [1, 1], [0.6, 1.2], [0.6, 1.2]]
+        # mean_before = [1, 1], mean_after = [0.6, 1.2]
+        # loss = [40, -20]
+        np.testing.assert_allclose(result, [40.0, -20.0], atol=1e-10)
+
+    def test_uniform_fractional_loss_gives_zero(self):
+        """A constant fractional loss across all shots normalizes away."""
+        instance = self._make_instance([0, 1], [2, 3])
+        data = np.array(
+            [
+                [100.0, 200.0, 150.0],
+                [100.0, 200.0, 150.0],
+                [50.0, 100.0, 75.0],
+                [50.0, 100.0, 75.0],
+            ]
+        )
+
+        result = instance.calc_tmit_loss(data)
+
+        np.testing.assert_allclose(result, [0.0, 0.0, 0.0], atol=1e-10)
+
+
+class TestRunSetup(TestCase):
+    """Test that model validation wires up BPMs and indices correctly."""
+
+    @patch("slac_measurements.tmit_loss.create_beampath")
+    def test_bpms_sorted_by_z_location(self, mock_create_beampath):
+        bpm_a = _make_mock_bpm("BPM_A", z_location=10.0)
+        bpm_b = _make_mock_bpm("BPM_B", z_location=5.0)
+        bpm_c = _make_mock_bpm("BPM_C", z_location=20.0)
+        mock_create_beampath.return_value = _make_mock_beampath(
+            {"BPM_A": bpm_a, "BPM_B": bpm_b, "BPM_C": bpm_c}
+        )
+
+        wire = _make_wire(
+            bpms_before=["BPM_B"],
+            bpms_after=["BPM_C"],
+        )
+
+        instance = TMITLoss(
+            buffer=MagicMock(),
+            beampath="TEST",
+            beam_profile_device=wire,
+        )
+
+        self.assertEqual(list(instance.bpms.keys()), ["BPM_B", "BPM_A", "BPM_C"])
+
+    @patch("slac_measurements.tmit_loss.create_beampath")
+    def test_indices_resolve_correctly(self, mock_create_beampath):
+        bpm_a = _make_mock_bpm("BPM_A", z_location=1.0)
+        bpm_b = _make_mock_bpm("BPM_B", z_location=2.0)
+        bpm_c = _make_mock_bpm("BPM_C", z_location=3.0)
+        bpm_d = _make_mock_bpm("BPM_D", z_location=4.0)
+        mock_create_beampath.return_value = _make_mock_beampath(
+            {"BPM_A": bpm_a, "BPM_B": bpm_b, "BPM_C": bpm_c, "BPM_D": bpm_d}
+        )
+
+        wire = _make_wire(
+            bpms_before=["BPM_A", "BPM_B"],
+            bpms_after=["BPM_C", "BPM_D"],
+        )
+
+        instance = TMITLoss(
+            buffer=MagicMock(),
+            beampath="TEST",
+            beam_profile_device=wire,
+        )
+
+        self.assertEqual(instance.idx_before, [0, 1])
+        self.assertEqual(instance.idx_after, [2, 3])
+
+    @patch("slac_measurements.tmit_loss.create_beampath")
+    def test_missing_bpms_skipped(self, mock_create_beampath):
+        bpm_a = _make_mock_bpm("BPM_A", z_location=1.0)
+        bpm_b = _make_mock_bpm("BPM_B", z_location=2.0)
+        mock_create_beampath.return_value = _make_mock_beampath(
+            {"BPM_A": bpm_a, "BPM_B": bpm_b}
+        )
+
+        wire = _make_wire(
+            bpms_before=["BPM_A", "BPM_MISSING"],
+            bpms_after=["BPM_B", "BPM_GONE"],
+        )
+
+        instance = TMITLoss(
+            buffer=MagicMock(),
+            beampath="TEST",
+            beam_profile_device=wire,
+        )
+
+        self.assertEqual(instance.idx_before, [0])
+        self.assertEqual(instance.idx_after, [1])
+
+    @patch("slac_measurements.tmit_loss.create_beampath")
+    def test_empty_beampath_raises(self, mock_create_beampath):
+        mock_create_beampath.return_value = _make_mock_beampath({})
+
+        wire = _make_wire(bpms_before=[], bpms_after=[])
+
+        with self.assertRaises(LookupError):
+            TMITLoss(
+                buffer=MagicMock(),
+                beampath="TEST",
+                beam_profile_device=wire,
+            )
+
+
+class TestMeasure(TestCase):
+    """Test the full measure pipeline with mocked data collection."""
+
+    @patch("slac_measurements.tmit_loss.collect_with_size_check")
+    @patch("slac_measurements.tmit_loss.create_beampath")
+    def test_measure_returns_numpy_array(self, mock_create_beampath, mock_collect):
+        bpm_a = _make_mock_bpm("BPM_A", z_location=1.0)
+        bpm_b = _make_mock_bpm("BPM_B", z_location=2.0)
+        bpm_c = _make_mock_bpm("BPM_C", z_location=3.0)
+        bpm_d = _make_mock_bpm("BPM_D", z_location=4.0)
+        mock_create_beampath.return_value = _make_mock_beampath(
+            {"BPM_A": bpm_a, "BPM_B": bpm_b, "BPM_C": bpm_c, "BPM_D": bpm_d}
+        )
+
+        wire = _make_wire(
+            bpms_before=["BPM_A", "BPM_B"],
+            bpms_after=["BPM_C", "BPM_D"],
+        )
+
+        mock_collect.side_effect = [
+            np.array([2.0, 4.0]),
+            np.array([2.0, 4.0]),
+            np.array([2.0, 4.0]),
+            np.array([2.0, 4.0]),
+        ]
+
+        instance = TMITLoss(
+            buffer=MagicMock(),
+            beampath="TEST",
+            beam_profile_device=wire,
+        )
+
+        result = instance.measure()
+
+        self.assertIsInstance(result, np.ndarray)
+        np.testing.assert_allclose(result, [0.0, 0.0], atol=1e-10)
+
+    @patch("slac_measurements.tmit_loss.collect_with_size_check")
+    @patch("slac_measurements.tmit_loss.create_beampath")
+    def test_measure_with_loss(self, mock_create_beampath, mock_collect):
+        bpm_a = _make_mock_bpm("BPM_A", z_location=1.0)
+        bpm_b = _make_mock_bpm("BPM_B", z_location=2.0)
+        bpm_c = _make_mock_bpm("BPM_C", z_location=3.0)
+        bpm_d = _make_mock_bpm("BPM_D", z_location=4.0)
+        mock_create_beampath.return_value = _make_mock_beampath(
+            {"BPM_A": bpm_a, "BPM_B": bpm_b, "BPM_C": bpm_c, "BPM_D": bpm_d}
+        )
+
+        wire = _make_wire(
+            bpms_before=["BPM_A", "BPM_B"],
+            bpms_after=["BPM_C", "BPM_D"],
+        )
+
+        mock_collect.side_effect = [
+            np.array([2.0, 4.0]),
+            np.array([2.0, 4.0]),
+            np.array([1.0, 4.0]),
+            np.array([1.0, 4.0]),
+        ]
+
+        instance = TMITLoss(
+            buffer=MagicMock(),
+            beampath="TEST",
+            beam_profile_device=wire,
+        )
+
+        result = instance.measure()
+
+        np.testing.assert_allclose(result, [40.0, -20.0], atol=1e-10)


### PR DESCRIPTION
This pull request refactors and modernizes the `TMITLoss` measurement code, simplifying its dependencies, improving maintainability, and introducing comprehensive unit tests. The main changes include a full rewrite of the `TMITLoss` class to remove its reliance on `pandas`, streamline data collection and normalization, and clarify the process of identifying upstream and downstream BPMs. Additionally, the dependency on pandas is removed from the project, and a new test suite is added to verify the correctness of the TMIT loss calculations and object initialization.

**Major refactor and modernization of `TMITLoss`:**

- Complete rewrite of `slac_measurements/tmit_loss.py` to remove pandas, clarify the measurement logic, and use direct numpy operations for TMIT loss calculation. The new implementation sorts BPMs by z-location, determines upstream/downstream indices based on wire metadata, and collects data using EPICS PVs, improving clarity and maintainability.
- The instantiation of `TMITLoss` in `slac_measurements/wires/collection.py` is updated to match the new argument names (`buffer`, `beam_profile_device`), removing the unused `region` argument.

**Dependency cleanup:**

- The `pandas` dependency is removed from `pyproject.toml` as it is no longer required by the refactored code. 

**Testing improvements:**

- A comprehensive new test suite is added in `tests/test_tmit_loss.py` to verify the core TMIT loss calculation logic, the correct wiring of BPMs and indices, and the full measurement pipeline using mocks. This ensures correctness and robustness of the new implementation.