### PR TITLE
Add option to weight emittance fits by inverse beam size.

### DIFF
--- a/slac_measurements/emittance.py
+++ b/slac_measurements/emittance.py
@@ -11,6 +11,7 @@ def compute_emit_bmag(
     beamsize_squared: np.ndarray,
     rmat: np.ndarray,
     twiss_design: np.ndarray = None,
+    weighted_fit: bool = False,
     maxiter: int = None,
 ):
     """
@@ -40,6 +41,10 @@ def compute_emit_bmag(
         to each measurement in the respective batch for the calculation of Bmag
         (useful for quad scans).
 
+    weighted_fit : bool, default = False
+        Boolean specifying whether or not to weight the fitting loss function by the inverse beam
+        size. If True, smaller beam sizes will be prioritized in the non-linear curve fitting.
+
     maxiter : int, optional
         Maximum number of iterations to perform in nonlinear fitting (minimization algorithm).
 
@@ -55,7 +60,7 @@ def compute_emit_bmag(
           where sig11, sig12, sig22 are the reconstructed beam matrix parameters at the entrance
           of the measurement quad.
         - 'twiss_at_reconstruction': numpy.ndarray of shape (batchshape x nsteps x 3) containing the
-          reconstructed twiss parameters at the reference point (e.g. right before the quad in a quad 
+          reconstructed twiss parameters at the reference point (e.g. right before the quad in a quad
           scan or at the reference beam profile device in a multi measurement).
         - 'twiss': numpy.ndarray of shape (batchshape x nsteps x 3) containing the
           reconstructed twiss parameters at each measurement point (e.g. at the beam profile
@@ -101,8 +106,14 @@ def compute_emit_bmag(
             params = torch.reshape(params, [*beamsize_squared.shape[:-2], 3])
             sig = torch.stack(beam_matrix_tuple(params), dim=-1).unsqueeze(-1)
             # sig should now be shape batchshape x 3 x 1 (column vectors)
+            if weighted_fit:
+                weights = 1.0 / beamsize_squared.sqrt()
+            else:
+                weights = 1.0
             total_abs_error = (
-                (torch.sqrt(amat @ sig) - torch.sqrt(beamsize_squared)).abs().nansum()
+                (weights * (torch.sqrt(amat @ sig) - torch.sqrt(beamsize_squared)))
+                .abs()
+                .nansum()
             )
             return total_abs_error
 
@@ -122,8 +133,12 @@ def compute_emit_bmag(
             params = np.reshape(params, [*beamsize_squared.shape[:-2], 3])
             sig = np.expand_dims(np.stack(beam_matrix_tuple(params), axis=-1), axis=-1)
             # sig should now be shape batchshape x 3 x 1 (column vectors)
+            if weighted_fit:
+                weights = 1.0 / np.sqrt(beamsize_squared)
+            else:
+                weights = 1.0
             total_abs_error = np.nansum(
-                np.abs(np.sqrt(amat @ sig) - np.sqrt(beamsize_squared))
+                np.abs(weights * (np.sqrt(amat @ sig) - np.sqrt(beamsize_squared)))
             )
             return total_abs_error
 
@@ -190,7 +205,7 @@ def compute_emit_bmag(
 
     # get twiss params from beam matrix
     rv["twiss_at_reconstruction"] = _twiss_from_beam_matrix(rv["beam_matrix"])
-    
+
     # propagate twiss params to beam profile device (expand_dims for broadcasting)
     rv["twiss"] = propagate_twiss(_twiss_from_beam_matrix(rv["beam_matrix"]), rmat)
     # result shape (batchshape x nsteps x 3)


### PR DESCRIPTION
Adds boolean argument 'weighted_fit' specifying whether or not to weight the nonlinear fitting in the emittance calc by the inverse of the beam sizes. If True, smaller beam sizes will be prioritized in the nonlinear fitting.