### PR TITLE
Refactor buffer handling to use Buffer from slac_timing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "scikit-image",
     "torch",
     "slac-devices @ git+https://github.com/slaclab/slac-devices.git@main",
-    "slac-timing @ git+https://github.com/slaclab/slac-timing.git@main",
+    "slac-timing @ git+https://github.com/slaclab/slac-timing.git@master",
 ]
 description = "Tools to support high level application development at LCLS using Python"
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ dependencies = [
     "h5py",
     "scikit-image",
     "torch",
-    "slac-devices @ git+https://github.com/slaclab/slac-devices.git@main"
+    "slac-devices @ git+https://github.com/slaclab/slac-devices.git@main",
+    "slac-timing @ git+https://github.com/slaclab/slac-timing.git@main",
 ]
 description = "Tools to support high level application development at LCLS using Python"
 dynamic = ["version"]
@@ -33,9 +34,6 @@ requires-python = ">=3.10"
 [project.optional-dependencies]
 meme  = [
     "meme @ git+https://github.com/slaclab/meme.git@main" # note: direct dependency will block PyPI upload
-]
-edef  = [
-    "edef @ git+https://github.com/slaclab/edef.git@main"
 ]
 
 

--- a/slac_measurements/tmit_loss.py
+++ b/slac_measurements/tmit_loss.py
@@ -6,14 +6,14 @@ from slac_devices.beampath import Beampath
 from slac_devices.reader import create_beampath
 from slac_devices.wire import Wire
 from slac_measurements.measurement import Measurement
-from edef import BSABuffer, EventDefinition
+from slac_timing import Buffer
 
 
 class TMITLoss(Measurement):
     """Measures percentage beam intensity loss across a wire scanner."""
 
     name: str = "TMIT Loss"
-    buffer: BSABuffer | EventDefinition
+    buffer: Buffer
     beampath: str
     beam_profile_device: Wire
 

--- a/slac_measurements/tmit_loss.py
+++ b/slac_measurements/tmit_loss.py
@@ -64,7 +64,13 @@ class TMITLoss(Measurement):
                 print(f"Skipping BPM {name}: no buffer data")
                 rows.append(np.full(n_samples, np.nan))
             else:
-                rows.append(np.asarray(data, dtype=float))
+                arr = np.asarray(data, dtype=float)
+                if len(arr) != n_samples:
+                    padded = np.full(n_samples, np.nan)
+                    n = min(len(arr), n_samples)
+                    padded[:n] = arr[:n]
+                    arr = padded
+                rows.append(arr)
         return np.array(rows)
 
     @staticmethod

--- a/slac_measurements/utils.py
+++ b/slac_measurements/utils.py
@@ -1,7 +1,12 @@
 from typing import Annotated
+import logging
 import numpy as np
 from pydantic import BeforeValidator
 import time
+
+from slac_devices import Device
+
+from slac_timing import Buffer
 
 
 def calculate_statistics(data: np.ndarray, name):
@@ -18,7 +23,12 @@ def ensure_numpy_array(v):
 
 
 def collect_with_size_check(
-    device, collector_func, buffer, logger, max_retries=3, delay=3
+    device: Device,
+    collector_func: str,
+    buffer: Buffer,
+    logger: logging.Logger | None,
+    max_retries: int = 3,
+    delay: float = 3,
 ):
     """
     Collects data using the provided function and checks its size.
@@ -26,7 +36,7 @@ def collect_with_size_check(
     Parameters:
         device (Device): A slac-tools Device object
         collector_func (string): Function name (as a string) to collect data.
-        buffer (edef.BSABuffer): Buffer object containing measurement data.
+        buffer (Buffer): Buffer object containing measurement data.
         logger (logging.Logger): Logger for logging warnings.
         max_retries (int): Maximum number of retries on size mismatch.
         delay (float): Delay in seconds between retries.

--- a/slac_measurements/wires/buffer.py
+++ b/slac_measurements/wires/buffer.py
@@ -2,8 +2,10 @@ import logging
 import getpass
 import numpy as np
 
+from slac_timing import create_buffer, Buffer
 
-_BUFFER_NAME = "LCLS Tools Wire Scan"
+
+_BUFFER_NAME = "SLAC Tools Wire Scan"
 _MAX_BEAM_RATE = 16000
 _MIN_BEAM_RATE = 10
 
@@ -26,34 +28,23 @@ def reserve_buffer(
     pulses: int,
     beam_rate: int,
     name: str = _BUFFER_NAME,
-    destination_mode: str = "Inclusion",
     logger: logging.Logger | None = None,
-):
+) -> Buffer:
     user = _get_username()
     if logger:
         logger.info("Reserving buffer...")
 
-    if beampath.startswith("SC"):
-        return _reserve_bsa_buffer(
-            name=name,
-            beampath=beampath,
-            user=user,
-            n_measurements=_calculate_buffer_points(pulses, beam_rate),
-            destination_mode=destination_mode,
-            logger=logger,
-        )
+    buf = create_buffer(
+        beampath=beampath,
+        n_measurements=_calculate_buffer_points(pulses, beam_rate),
+        user=user,
+        name=name,
+    )
 
-    elif beampath.startswith("CU"):
-        return _reserve_edef_buffer(
-            name=name,
-            beampath=beampath,
-            user=user,
-            n_measurements=_calculate_buffer_points(pulses, beam_rate),
-            logger=logger,
-        )
+    if logger:
+        logger.info("Reserved timing buffer %s.", buf.number)
 
-    else:
-        raise BufferError(f"Unrecognized beampath: {beampath}")
+    return buf
 
 
 def _calculate_buffer_points(pulses, rate) -> int:
@@ -80,7 +71,6 @@ def _calculate_buffer_points(pulses, rate) -> int:
     if rate is None or rate <= 0:
         raise ValueError(f"Invalid beam rate: {rate}. Must be a positive number.")
 
-    # 16000 max rate, 10 min rate
     def _log_range():
         return np.log10(_MAX_BEAM_RATE) - np.log10(_MIN_BEAM_RATE)
 
@@ -88,57 +78,9 @@ def _calculate_buffer_points(pulses, rate) -> int:
         return (np.log10(rate) - np.log10(_MIN_BEAM_RATE)) / _log_range()
 
     def _fudge(rate):
-        return 1.5 - 0.4 * _rate_factor(rate)  # Fudge the calculation by 1.1 to 1.5
+        return 1.5 - 0.4 * _rate_factor(rate)
 
     def _n_measurements(pulses, rate):
         return int(pulses * 3 * _fudge(rate) + rate / 6)
 
     return _n_measurements(pulses, rate)
-
-
-def _reserve_bsa_buffer(
-    name: str,
-    beampath: str,
-    user: str,
-    n_measurements: int,
-    destination_mode: str,
-    logger: logging.Logger | None = None,
-):
-    import edef
-
-    if destination_mode not in ["Disable", "Exclusion", "Inclusion"]:
-        raise BufferError(f"Invalid destination mode: {destination_mode}")
-
-    buf = edef.BSABuffer(name=name, user=user)
-    buf.n_measurements = n_measurements
-    buf.destination_mode = destination_mode
-    buf.clear_masks()
-    buf.destination_masks = [beampath]
-    if logger:
-        logger.info("Reserved BSA Buffer %s.", buf.number)
-    return buf
-
-
-def _reserve_edef_buffer(
-    name: str,
-    beampath: str,
-    user: str,
-    n_measurements: int,
-    logger: logging.Logger | None = None,
-):
-    def _choose_beamcode(beampath):
-        if beampath.startswith("CU_HXR"):
-            return 1
-        elif beampath.startswith("CU_SXR"):
-            return 2
-        else:
-            raise BufferError(f"Unrecognized beampath for eDef: {beampath}")
-
-    import edef
-
-    buf = edef.EventDefinition(name=name, user=user)
-    buf.n_measurements = n_measurements
-    buf.beamcode = _choose_beamcode(beampath)
-    if logger:
-        logger.info("Reserved eDef Buffer %s.", buf.number)
-    return buf

--- a/slac_measurements/wires/collection.py
+++ b/slac_measurements/wires/collection.py
@@ -9,6 +9,7 @@ from pydantic import model_validator
 from typing_extensions import Self
 
 from slac_devices.wire import Wire
+from slac_timing import Buffer
 import slac_measurements.beam_profile
 import slac_measurements.wires.buffer
 import slac_measurements.utils
@@ -35,7 +36,7 @@ class BaseWireMeasurementCollection(
     Attributes:
         beam_profile_device (Wire): Wire device for the scan.
         beampath (str): Beamline identifier for buffer and device selection.
-        my_buffer: Timing buffer managing data acquisition.
+        buffer: Timing buffer managing data acquisition.
         devices (dict): Device objects (wire, detectors) used in the scan.
         data (dict): Raw buffered data by device name.
         logger (logging.Logger): File-based measurement logger.
@@ -44,7 +45,7 @@ class BaseWireMeasurementCollection(
     name: str = "Wire Beam Profile Measurement"
     beam_profile_device: Wire
     beampath: str
-    my_buffer: object | None = None
+    buffer: Buffer | None = None
     devices: dict | None = None
     detectors: list | None = None
     data: dict | None = None
@@ -73,14 +74,14 @@ class BaseWireMeasurementCollection(
         def _prepare_runtime_state() -> None:
             """Prepare per-run state that depends on an active timing buffer."""
 
-            self.my_buffer = self._reserve_buffer()
+            self.buffer = self._reserve_buffer()
             self.devices = self._create_device_dictionary()
             self.metadata = self._create_metadata()
 
         def _release_buffer_safely() -> None:
             """Release timing buffer after scan completion."""
 
-            buf = self.my_buffer
+            buf = self.buffer
             if buf is not None:
                 buffer_number = getattr(buf, "number", None)
                 try:
@@ -91,7 +92,7 @@ class BaseWireMeasurementCollection(
                         "Failed while releasing timing buffer %s.", buffer_number
                     )
                 finally:
-                    self.my_buffer = None
+                    self.buffer = None
 
         try:
             _prepare_runtime_state()
@@ -117,7 +118,7 @@ class BaseWireMeasurementCollection(
 
             if name == "TMITLOSS":
                 return slac_measurements.tmit_loss.TMITLoss(
-                    buffer=self.my_buffer,
+                    buffer=self.buffer,
                     beam_profile_device=self.beam_profile_device,
                     beampath=self.beampath,
                 )
@@ -190,7 +191,7 @@ class BaseWireMeasurementCollection(
 
         return MeasurementMetadata(
             wire_name=self.beam_profile_device.name,
-            buffer_number=self.my_buffer.number,
+            buffer_number=self.buffer.number,
             area=self.beam_profile_device.area,
             beampath=self.beampath,
             detectors=self.detectors,
@@ -229,7 +230,7 @@ class BaseWireMeasurementCollection(
                 )  # For devices like TMITLOSS that don't use buffer collection
 
             return slac_measurements.utils.collect_with_size_check(
-                device, buffer_method, self.my_buffer, self.logger
+                device, buffer_method, self.buffer, self.logger
             )
 
         self.logger.info("Getting data from timing buffer ...")
@@ -240,20 +241,20 @@ class BaseWireMeasurementCollection(
     def _reserve_buffer(self) -> object:
         """Reserve a timing buffer for the scan based on beampath and wire metadata."""
 
-        if self.my_buffer is None:
-            self.my_buffer = slac_measurements.wires.buffer.reserve_buffer(
+        if self.buffer is None:
+            self.buffer = slac_measurements.wires.buffer.reserve_buffer(
                 beampath=self.beampath,
                 logger=self.logger,
                 pulses=self.beam_profile_device.scan_pulses,
                 beam_rate=self.beam_profile_device.beam_rate,
             )
 
-        return self.my_buffer
+        return self.buffer
 
     def _calculate_acquisition_timeout_s(self) -> float:
         """Return timeout above minimum expected buffer acquisition time."""
 
-        n_points = getattr(self.my_buffer, "n_measurements", None)
+        n_points = getattr(self.buffer, "n_measurements", None)
         if n_points is None or n_points <= 0:
             raise RuntimeError(
                 f"Invalid buffer point count for timeout calculation: {n_points}"

--- a/slac_measurements/wires/otf_collection.py
+++ b/slac_measurements/wires/otf_collection.py
@@ -47,16 +47,16 @@ class OTFWireMeasurementCollection(BaseWireMeasurementCollection):
             self.logger.info("Starting buffer acquisition for on-the-fly scan...")
             acquisition_start = time.monotonic()
             acquisition_timeout_s = self._calculate_acquisition_timeout_s()
-            self.my_buffer.start()
+            self.buffer.start()
 
             time.sleep(0.5)
 
             i = 0
-            while not self.my_buffer.is_acquisition_complete():
+            while not self.buffer.is_complete():
                 elapsed_s = time.monotonic() - acquisition_start
                 if elapsed_s > acquisition_timeout_s:
                     raise TimeoutError(
-                        f"Timing buffer {self.my_buffer.number} did not complete after "
+                        f"Timing buffer {self.buffer.number} did not complete after "
                         f"{elapsed_s:.1f}s (timeout={acquisition_timeout_s:.1f}s)."
                     )
                 time.sleep(0.1)
@@ -67,7 +67,7 @@ class OTFWireMeasurementCollection(BaseWireMeasurementCollection):
 
             self.logger.info(
                 "Timing buffer %s acquisition complete after %.1f seconds",
-                self.my_buffer.number,
+                self.buffer.number,
                 time.monotonic() - acquisition_start,
             )
 

--- a/slac_measurements/wires/step_collection.py
+++ b/slac_measurements/wires/step_collection.py
@@ -108,7 +108,7 @@ class StepWireMeasurementCollection(BaseWireMeasurementCollection):
         self.logger.info("Starting buffer acquisition for step scan...")
         acquisition_start = time.monotonic()
         acquisition_timeout_s = self._calculate_acquisition_timeout_s()
-        self.my_buffer.start()
+        self.buffer.start()
 
         positions = _get_step_positions()
         total_positions = len(positions)
@@ -133,17 +133,17 @@ class StepWireMeasurementCollection(BaseWireMeasurementCollection):
 
         self.logger.info("Waiting for buffer acquisition to complete...")
 
-        while not self.my_buffer.is_acquisition_complete():
+        while not self.buffer.is_complete():
             elapsed_s = time.monotonic() - acquisition_start
             if elapsed_s > acquisition_timeout_s:
                 raise TimeoutError(
-                    f"Timing buffer {self.my_buffer.number} did not complete after "
+                    f"Timing buffer {self.buffer.number} did not complete after "
                     f"{elapsed_s:.1f}s (timeout={acquisition_timeout_s:.1f}s)."
                 )
             time.sleep(0.1)
 
         self.logger.info(
             "Timing buffer %s acquisition complete after %.1f seconds",
-            self.my_buffer.number,
+            self.buffer.number,
             time.monotonic() - acquisition_start,
         )

--- a/tests/test_tmit_loss.py
+++ b/tests/test_tmit_loss.py
@@ -8,6 +8,37 @@ if "edef" not in sys.modules:
 
 from slac_devices.wire import Wire
 from slac_measurements.tmit_loss import TMITLoss
+from slac_timing import Buffer
+
+
+class _TestBuffer(Buffer):
+    """Minimal concrete Buffer for unit tests (no EPICS dependencies)."""
+
+    @property
+    def pv_prefix(self) -> str:
+        return "TEST:SYS0:1"
+
+    def _create_pvs(self):
+        return MagicMock()
+
+    def _reserve(self) -> int:
+        return 1
+
+    def release(self) -> None:
+        pass
+
+    def start(self) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def is_complete(self) -> bool:
+        return True
+
+    @property
+    def num_acquired(self) -> int:
+        return self.n_measurements
 
 
 def _make_mock_bpm(name, z_location, control_name):
@@ -114,7 +145,7 @@ class TestRunSetup(TestCase):
         )
 
         instance = TMITLoss(
-            buffer=MagicMock(),
+            buffer=_TestBuffer(name="TEST", user="test", n_measurements=2),
             beampath="TEST",
             beam_profile_device=wire,
         )
@@ -137,7 +168,7 @@ class TestRunSetup(TestCase):
         )
 
         instance = TMITLoss(
-            buffer=MagicMock(),
+            buffer=_TestBuffer(name="TEST", user="test", n_measurements=2),
             beampath="TEST",
             beam_profile_device=wire,
         )
@@ -159,7 +190,7 @@ class TestRunSetup(TestCase):
         )
 
         instance = TMITLoss(
-            buffer=MagicMock(),
+            buffer=_TestBuffer(name="TEST", user="test", n_measurements=2),
             beampath="TEST",
             beam_profile_device=wire,
         )
@@ -175,7 +206,7 @@ class TestRunSetup(TestCase):
 
         with self.assertRaises(LookupError):
             TMITLoss(
-                buffer=MagicMock(),
+                buffer=_TestBuffer(name="TEST", user="test", n_measurements=2),
                 beampath="TEST",
                 beam_profile_device=wire,
             )
@@ -208,11 +239,8 @@ class TestMeasure(TestCase):
             bpms_after=["BPM_C", "BPM_D"],
         )
 
-        mock_buffer = MagicMock()
-        mock_buffer.n_measurements = 2
-
         instance = TMITLoss(
-            buffer=mock_buffer,
+            buffer=_TestBuffer(name="TEST", user="test", n_measurements=2),
             beampath="TEST",
             beam_profile_device=wire,
         )
@@ -246,11 +274,8 @@ class TestMeasure(TestCase):
             bpms_after=["BPM_C", "BPM_D"],
         )
 
-        mock_buffer = MagicMock()
-        mock_buffer.n_measurements = 2
-
         instance = TMITLoss(
-            buffer=mock_buffer,
+            buffer=_TestBuffer(name="TEST", user="test", n_measurements=2),
             beampath="TEST",
             beam_profile_device=wire,
         )


### PR DESCRIPTION
This pull request refactors the timing buffer management in the codebase to standardize on the new `slac-timing` package, removing dependencies on the older `edef` package and its buffer types. The changes simplify buffer handling, unify naming conventions, and update the buffer reservation and usage logic across measurement and wire scan modules.

**Migration to `slac-timing` and Buffer Handling Simplification:**

* Replaced all uses of `edef.BSABuffer` and `edef.EventDefinition` with `slac_timing.Buffer` throughout the codebase, including in type annotations, imports, and buffer management logic. The buffer reservation logic now uses a single unified `create_buffer` function from `slac_timing`, eliminating the need for separate BSA and eDef buffer handling. 

* Updated buffer attribute names from `my_buffer` to `buffer` in wire scan collection classes and all related methods, improving clarity and consistency. All buffer-related method calls and attribute accesses have been updated accordingly. 

**Dependency and Import Updates:**

* Added `slac-timing` as a dependency in `pyproject.toml` and removed the now-unused `edef` dependency. Updated all relevant import statements to use `slac_timing`. 

**Naming and Metadata Improvements:**

* Changed the default buffer name from `"LCLS Tools Wire Scan"` to `"SLAC Tools Wire Scan"` for consistency with the new timing buffer system.

These changes modernize the timing buffer infrastructure, reduce complexity, and prepare the codebase for future enhancements using the `slac-timing` package.