### PR TITLE
Refactor TMITLoss data collection and update deprecation warnings

### DIFF
--- a/slac_measurements/tmit_loss.py
+++ b/slac_measurements/tmit_loss.py
@@ -55,16 +55,16 @@ class TMITLoss(Measurement):
         all_data = {}
         for area in self._beampath_obj.areas.values():
             if area.bpm_collection:
-                all_data.update(area.bpm_collection.get_buffer_data(self.buffer))
+                all_data.update(
+                    area.bpm_collection.get_buffer_data(self.buffer, pad=True)
+                )
 
-        rows = []
-        for name in bpm_names:
-            data = all_data.get(name)
-            if data is None:
-                print(f"Skipping BPM {name}: no buffer data")
-                rows.append(np.full(n_samples, np.nan))
-            else:
-                rows.append(np.asarray(data, dtype=float))
+        rows = [
+            np.asarray(all_data[name], dtype=float)
+            if name in all_data
+            else np.full(n_samples, np.nan)
+            for name in bpm_names
+        ]
         return np.array(rows)
 
     @staticmethod

--- a/slac_measurements/utils.py
+++ b/slac_measurements/utils.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Annotated
 import numpy as np
 from pydantic import BeforeValidator
@@ -21,19 +22,17 @@ def collect_with_size_check(
     device, collector_func, buffer, logger, max_retries=3, delay=3
 ):
     """
+    Deprecated: Use buffer.get(pv, retries=N, retry_delay=D) instead.
+
     Collects data using the provided function and checks its size.
     Retries collection if the data size does not match the expected points.
-    Parameters:
-        device (Device): A slac-tools Device object
-        collector_func (string): Function name (as a string) to collect data.
-        buffer (edef.BSABuffer): Buffer object containing measurement data.
-        logger (logging.Logger): Logger for logging warnings.
-        max_retries (int): Maximum number of retries on size mismatch.
-        delay (float): Delay in seconds between retries.
-        *args, **kwargs: Arguments to pass to the collector function.
-    Returns:
-        Collected data if size matches expected points.
     """
+    warnings.warn(
+        "collect_with_size_check is deprecated. "
+        "Use buffer.get(pv, retries=N) or device.method(buffer, retries=N) instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     method = getattr(device, collector_func)
     for attempt in range(max_retries):
         data = method(buffer)

--- a/slac_measurements/wires/collection.py
+++ b/slac_measurements/wires/collection.py
@@ -226,8 +226,9 @@ class BaseWireMeasurementCollection(
             if buffer_method is None:
                 return device.measure()
 
-            method = getattr(device, buffer_method)
-            return method(self.buffer, retries=3, retry_delay=3.0)
+            return getattr(device, buffer_method)(
+                self.buffer, retries=3, retry_delay=3.0
+            )
 
         self.logger.info("Getting data from timing buffer ...")
         data = {name: _collect_device_data(name) for name in self.devices.keys()}

--- a/slac_measurements/wires/collection.py
+++ b/slac_measurements/wires/collection.py
@@ -11,7 +11,6 @@ from typing_extensions import Self
 from slac_devices.wire import Wire
 import slac_measurements.beam_profile
 import slac_measurements.wires.buffer
-import slac_measurements.utils
 from slac_measurements.wires.collection_results import (
     MeasurementMetadata,
     WireMeasurementCollectionResult,
@@ -224,13 +223,10 @@ class BaseWireMeasurementCollection(
             buffer_method = _get_buffer_collection_method(device_name)
 
             if buffer_method is None:
-                return (
-                    device.measure()
-                )  # For devices like TMITLOSS that don't use buffer collection
+                return device.measure()
 
-            return slac_measurements.utils.collect_with_size_check(
-                device, buffer_method, self.my_buffer, self.logger
-            )
+            method = getattr(device, buffer_method)
+            return method(self.buffer, retries=3, retry_delay=3.0)
 
         self.logger.info("Getting data from timing buffer ...")
         data = {name: _collect_device_data(name) for name in self.devices.keys()}


### PR DESCRIPTION
This pull request introduces several improvements and refactors to buffer data collection, with a focus on deprecating the custom `collect_with_size_check` utility in favor of standardized buffer methods and improving code clarity. The most important changes are grouped below:

**Deprecation and Refactoring of Data Collection Utilities:**

* Marked the `collect_with_size_check` function in `slac_measurements/utils.py` as deprecated, added a warning, and updated its docstring to direct users to use `buffer.get` or device-specific methods with retries instead.
* Updated `slac_measurements/wires/collection.py` to stop using the deprecated `collect_with_size_check` and instead directly call the appropriate buffer method with retry parameters.

**Buffer Data Handling Improvements:**

* Changed the call to `get_buffer_data` in `_get_bpm_data` to always use padding (`pad=True`), and refactored the construction of the `rows` array for improved readability and efficiency.

**Code Cleanup:**

* Removed an unnecessary import of `slac_measurements.utils` from `slac_measurements/wires/collection.py` since the deprecated function is no longer used.
* Added an import of the `warnings` module to `slac_measurements/utils.py` to support the new deprecation warning.