### PR TITLE
Wire Scan Jitter Correction

### DIFF
--- a/slac_measurements/wires/__init__.py
+++ b/slac_measurements/wires/__init__.py
@@ -21,3 +21,6 @@ from slac_measurements.wires.collection_results import (
 
 # Collection factory and mode type — for advanced users constructing collections directly
 from slac_measurements.wires.collection import ScanMode, create_wire_collection
+
+# Jitter correction — optional post-collection processing
+from slac_measurements.wires.jitter_correction import correct_jitter

--- a/slac_measurements/wires/analysis.py
+++ b/slac_measurements/wires/analysis.py
@@ -7,6 +7,7 @@ import warnings
 from typing import Literal
 
 import slac_measurements.beam_profile
+from slac_measurements.wires.coordinates import stage_to_beam, beam_to_stage
 from slac_measurements.wires.analysis_results import (
     DetectorFit,
     DetectorProfileMeasurement,
@@ -109,13 +110,9 @@ class WireMeasurementAnalysis(slac_measurements.beam_profile.BeamProfileAnalysis
             profile: str, positions: np.ndarray
         ) -> np.ndarray:
             """Convert stage positions to beam coordinates for a given profile."""
-            scale = _extract_wire_angle()
-            return positions * abs(scale[profile])
-
-        def _extract_wire_angle() -> dict:
-            """Extract the wire install angle (in radians) for coordinate conversion."""
-            rad = np.deg2rad(self.collection_result.metadata.install_angle)
-            return {"x": np.sin(rad), "y": np.cos(rad), "u": 1.0}
+            return stage_to_beam(
+                positions, profile, self.collection_result.metadata.install_angle
+            )
 
         def _fit_detector_in_profile(
             x_beam: np.ndarray, detector_signal: np.ndarray, profile: str
@@ -137,8 +134,9 @@ class WireMeasurementAnalysis(slac_measurements.beam_profile.BeamProfileAnalysis
                 fp = fitting_module.fit(pos=peak_window[0], data=peak_window[1])
 
             # Convert mean from beam coordinates back to stage coordinates
-            scale = _extract_wire_angle()
-            mean_stage = fp["mean"] / abs(scale[profile])
+            mean_stage = beam_to_stage(
+                fp["mean"], profile, self.collection_result.metadata.install_angle
+            )
 
             # Generate fit curve (in beam coordinates)
             # Build kwargs dynamically to handle different fit types

--- a/slac_measurements/wires/collection.py
+++ b/slac_measurements/wires/collection.py
@@ -2,7 +2,9 @@ import logging
 from abc import ABC, abstractmethod
 from datetime import datetime
 from pathlib import Path
-from typing import Literal, Self
+from typing import Literal
+
+from typing_extensions import Self
 
 from pydantic import model_validator
 from slac_devices.wire import Wire

--- a/slac_measurements/wires/collection.py
+++ b/slac_measurements/wires/collection.py
@@ -2,16 +2,11 @@ import logging
 from abc import ABC, abstractmethod
 from datetime import datetime
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Self
 
-import numpy as np
 from pydantic import model_validator
-from typing_extensions import Self
-
 from slac_devices.wire import Wire
 import slac_measurements.beam_profile
-import slac_measurements.wires.buffer
-import slac_measurements.utils
 from slac_measurements.wires.collection_results import (
     MeasurementMetadata,
     WireMeasurementCollectionResult,
@@ -50,6 +45,7 @@ class BaseWireMeasurementCollection(
     data: dict | None = None
     logger: logging.Logger | None = None
     metadata: MeasurementMetadata | None = None
+    jitter_bpms: bool = False
 
     def measure(self) -> WireMeasurementCollectionResult:
         """
@@ -126,6 +122,7 @@ class BaseWireMeasurementCollection(
             create_by_prefix = {
                 "LBLM": slac_devices.reader.create_lblm,
                 "PMT": slac_devices.reader.create_pmt,
+                "BPM": slac_devices.reader.create_bpm,
             }
 
             creator = next(
@@ -156,6 +153,16 @@ class BaseWireMeasurementCollection(
             detector = _instantiate_device(name, area)
             if detector is not None:
                 devices[name] = detector
+
+        # Add jitter correction BPMs if defined
+        jitter_bpm_names = self.beam_profile_device.metadata.jitter_correction_bpms
+        if jitter_bpm_names:
+            area = self.beam_profile_device.area
+            for name in jitter_bpm_names:
+                bpm = _instantiate_device(name, area)
+                if bpm is not None:
+                    devices[name] = bpm
+            self.jitter_bpms = True
 
         self.logger.info("Device dictionary built.")
         return devices
@@ -206,6 +213,8 @@ class BaseWireMeasurementCollection(
     def _get_data_from_buffer(self) -> dict:
         """Collects wire scan and detector data after buffer completes."""
 
+        import slac_measurements.utils
+
         def _get_buffer_collection_method(device_name: str) -> str | None:
             """Determine the buffer collection method for a given device based on its name."""
 
@@ -215,26 +224,41 @@ class BaseWireMeasurementCollection(
                 return "fast_buffer"
             elif device_name.startswith("PMT"):
                 return "qdcraw_buffer"
+            elif device_name.startswith("BPM"):
+                return "bpm"
             else:
                 return None
 
-        def _collect_device_data(device_name: str) -> np.ndarray:
-            """Collect data for a given device using the appropriate method."""
+        def _collect_device_data(device_name: str, data: dict) -> None:
+            """Collect data for a given device and add to data dict."""
 
             device = self.devices[device_name]
             buffer_method = _get_buffer_collection_method(device_name)
 
             if buffer_method is None:
-                return (
-                    device.measure()
-                )  # For devices like TMITLOSS that don't use buffer collection
+                data[device_name] = device.measure()
+                return
 
-            return slac_measurements.utils.collect_with_size_check(
+            if buffer_method == "bpm":
+                x_data = slac_measurements.utils.collect_with_size_check(
+                    device, "x_buffer", self.my_buffer, self.logger
+                )
+                y_data = slac_measurements.utils.collect_with_size_check(
+                    device, "y_buffer", self.my_buffer, self.logger
+                )
+                data[f"{device_name}:X"] = x_data
+                data[f"{device_name}:Y"] = y_data
+                return
+
+            data[device_name] = slac_measurements.utils.collect_with_size_check(
                 device, buffer_method, self.my_buffer, self.logger
             )
 
         self.logger.info("Getting data from timing buffer ...")
-        data = {name: _collect_device_data(name) for name in self.devices.keys()}
+        data = {}
+        for name in self.devices:
+            _collect_device_data(name, data)
+
         self.logger.info("Data retrieved from buffer. Scan complete.")
         return data
 

--- a/slac_measurements/wires/collection.py
+++ b/slac_measurements/wires/collection.py
@@ -47,7 +47,6 @@ class BaseWireMeasurementCollection(
     data: dict | None = None
     logger: logging.Logger | None = None
     metadata: MeasurementMetadata | None = None
-    jitter_bpms: bool = False
 
     def measure(self) -> WireMeasurementCollectionResult:
         """
@@ -163,7 +162,6 @@ class BaseWireMeasurementCollection(
                 bpm = _instantiate_device(name, area)
                 if bpm is not None:
                     devices[name] = bpm
-            self.jitter_bpms = True
 
         self.logger.info("Device dictionary built.")
         return devices

--- a/slac_measurements/wires/collection.py
+++ b/slac_measurements/wires/collection.py
@@ -224,7 +224,7 @@ class BaseWireMeasurementCollection(
             elif device_name.startswith("PMT"):
                 return "qdcraw_buffer"
             elif device_name.startswith("BPM"):
-                return "bpm"
+                return "bpm_buffer"
             else:
                 return None
 
@@ -236,6 +236,12 @@ class BaseWireMeasurementCollection(
 
             if buffer_method is None:
                 return device.measure()
+
+            if buffer_method == "bpm_buffer":
+                return {
+                    "x": device.x_buffer(self.buffer, retries=3, retry_delay=3.0),
+                    "y": device.y_buffer(self.buffer, retries=3, retry_delay=3.0),
+                }
 
             return getattr(device, buffer_method)(
                 self.buffer, retries=3, retry_delay=3.0

--- a/slac_measurements/wires/collection_results.py
+++ b/slac_measurements/wires/collection_results.py
@@ -41,6 +41,9 @@ class WireMeasurementCollectionResult(BeamProfileCollectionResult):
     model_config = ConfigDict(arbitrary_types_allowed=True)
     raw_data: dict[str, Any]
     metadata: MeasurementMetadata
+    jitter_corrected: bool = False
+    jitter_rms_x: float | None = None
+    jitter_rms_y: float | None = None
 
     def __repr__(self) -> str:
         """Return a string representation of the WireMeasurementCollectionResult."""
@@ -76,6 +79,13 @@ class WireMeasurementCollectionResult(BeamProfileCollectionResult):
             # Save raw data
             raw_data_group = f.create_group("raw_data")
             self._save_raw_data(raw_data_group)
+
+            # Save jitter correction info
+            f.attrs["jitter_corrected"] = self.jitter_corrected
+            if self.jitter_rms_x is not None:
+                f.attrs["jitter_rms_x"] = self.jitter_rms_x
+            if self.jitter_rms_y is not None:
+                f.attrs["jitter_rms_y"] = self.jitter_rms_y
 
     def _save_metadata(self, group: h5py.Group) -> None:
         """Save measurement metadata as HDF5 attributes and datasets."""
@@ -152,9 +162,17 @@ def load_from_h5(filepath: str) -> WireMeasurementCollectionResult:
         # Load raw data
         raw_data = _load_raw_data(f["raw_data"])
 
+        # Load jitter correction info
+        jitter_corrected = bool(f.attrs.get("jitter_corrected", False))
+        jitter_rms_x = f.attrs.get("jitter_rms_x", None)
+        jitter_rms_y = f.attrs.get("jitter_rms_y", None)
+
     return WireMeasurementCollectionResult(
         raw_data=raw_data,
         metadata=metadata,
+        jitter_corrected=jitter_corrected,
+        jitter_rms_x=float(jitter_rms_x) if jitter_rms_x is not None else None,
+        jitter_rms_y=float(jitter_rms_y) if jitter_rms_y is not None else None,
     )
 
 

--- a/slac_measurements/wires/coordinates.py
+++ b/slac_measurements/wires/coordinates.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+
+def wire_angle_scales(install_angle_deg: float) -> dict[str, float]:
+    """Scale factors for converting between stage and beam coordinates.
+
+    Parameters
+    ----------
+    install_angle_deg : float
+        Wire installation angle in degrees.
+
+    Returns
+    -------
+    dict[str, float]
+        {"x": sin(angle), "y": cos(angle), "u": 1.0}
+    """
+    rad = np.radians(install_angle_deg)
+    return {"x": np.sin(rad), "y": np.cos(rad), "u": 1.0}
+
+
+def stage_to_beam(
+    positions: np.ndarray, profile: str, install_angle_deg: float
+) -> np.ndarray:
+    """Convert wire stage positions to beam coordinates for a profile."""
+    scales = wire_angle_scales(install_angle_deg)
+    return positions * abs(scales[profile])
+
+
+def beam_to_stage(
+    positions: np.ndarray, profile: str, install_angle_deg: float
+) -> np.ndarray:
+    """Convert beam coordinates back to wire stage positions for a profile."""
+    scales = wire_angle_scales(install_angle_deg)
+    return positions / abs(scales[profile])
+
+
+def xy_to_stage(
+    jitter_x: np.ndarray, jitter_y: np.ndarray, install_angle_deg: float
+) -> np.ndarray:
+    """Project x/y beam jitter onto the wire stage direction."""
+    scales = wire_angle_scales(install_angle_deg)
+    return jitter_x * scales["x"] + jitter_y * scales["y"]

--- a/slac_measurements/wires/jitter_correction.py
+++ b/slac_measurements/wires/jitter_correction.py
@@ -88,7 +88,7 @@ def get_jitter_rmat(
     wire_name : str
         Wire device name (MAD element name).
     bpm_names : list[str]
-        BPM control names (e.g., ["BPMS:HTR:120", "BPMS:HTR:320"]).
+        BPM element names (MAD names, e.g., ["BPM10", "BPM11"]).
     beampath : str
         Beam path identifier for the model.
     physics_model : str

--- a/slac_measurements/wires/jitter_correction.py
+++ b/slac_measurements/wires/jitter_correction.py
@@ -132,34 +132,33 @@ def get_jitter_rmat(
 
 
 def _extract_bpm_data(
-    raw_data: dict[str, np.ndarray],
+    raw_data: dict,
 ) -> tuple[np.ndarray, np.ndarray, list[str]]:
     """Extract BPM x/y position data from raw_data dictionary.
 
-    Identifies BPM data by keys starting with 'BPM' and ending in ':X' / ':Y'.
-    The MAD device name is used as the BPM identifier.
+    BPM entries are keyed by device name (starting with 'BPM') and contain
+    a dict with 'x' and 'y' buffer arrays.
 
     Returns
     -------
     tuple
         (bpm_x_array, bpm_y_array, bpm_names) where arrays are
-        [N_bpms x N_pulses] and bpm_names are MAD device names.
+        [N_bpms x N_pulses] and bpm_names are device names.
     """
-    bpm_x_keys = sorted(k for k in raw_data if k.startswith("BPM") and k.endswith(":X"))
+    bpm_keys = sorted(k for k in raw_data if k.startswith("BPM"))
 
     bpm_names = []
     x_arrays = []
     y_arrays = []
 
-    for x_key in bpm_x_keys:
-        name = x_key[:-2]  # Strip ':X'
-        y_key = f"{name}:Y"
+    for name in bpm_keys:
+        bpm_data = raw_data[name]
 
-        if y_key not in raw_data:
+        if not isinstance(bpm_data, dict):
             continue
 
-        x_arr = raw_data[x_key]
-        y_arr = raw_data[y_key]
+        x_arr = bpm_data.get("x")
+        y_arr = bpm_data.get("y")
 
         if x_arr is None or y_arr is None:
             continue

--- a/slac_measurements/wires/jitter_correction.py
+++ b/slac_measurements/wires/jitter_correction.py
@@ -1,0 +1,224 @@
+import numpy as np
+
+from slac_measurements.wires.collection_results import WireMeasurementCollectionResult
+from slac_measurements.wires.coordinates import xy_to_stage
+
+
+def correct_jitter(
+    collection_result: WireMeasurementCollectionResult,
+    beampath: str,
+    physics_model: str = "BLEM",
+    include_energy: bool = True,
+) -> WireMeasurementCollectionResult:
+    """Apply jitter correction to a wire scan collection result.
+
+    Uses BPM position data and transport matrices to reconstruct beam
+    position jitter at the wire location, then subtracts it from the
+    wire position data.
+
+    Parameters
+    ----------
+    collection_result : WireMeasurementCollectionResult
+        Raw collection result containing wire positions and BPM x/y buffer data.
+    beampath : str
+        Beam path identifier for the model (e.g., "SC_HXR", "SC_DIAG0").
+    physics_model : str
+        Model source for R-matrix retrieval. Default "BLEM".
+    include_energy : bool
+        Whether to include the dispersion (energy) term in the orbit fit.
+
+    Returns
+    -------
+    WireMeasurementCollectionResult
+        New collection result with corrected wire positions,
+        jitter_corrected=True, and jitter_rms_x/jitter_rms_y populated.
+
+    Raises
+    ------
+    ValueError
+        If no BPM data is found in the collection result or if fewer than
+        2 BPMs have valid data.
+    """
+    wire_name = collection_result.metadata.wire_name
+    install_angle = collection_result.metadata.install_angle
+    raw_data = collection_result.raw_data
+
+    bpm_x_data, bpm_y_data, bpm_names = _extract_bpm_data(raw_data)
+
+    if len(bpm_names) < 2:
+        raise ValueError(
+            f"Jitter correction requires at least 2 BPMs with valid data, "
+            f"found {len(bpm_names)}."
+        )
+
+    rmat_x, rmat_y = get_jitter_rmat(
+        wire_name, bpm_names, beampath, physics_model, include_energy
+    )
+
+    wire_positions = raw_data[wire_name].copy()
+
+    jitter_x, jitter_y = _compute_orbit_fit(bpm_x_data, bpm_y_data, rmat_x, rmat_y)
+
+    jitter_stage = xy_to_stage(jitter_x, jitter_y, install_angle)
+    corrected_positions = wire_positions - jitter_stage
+
+    corrected_raw_data = dict(raw_data)
+    corrected_raw_data[wire_name] = corrected_positions
+
+    return WireMeasurementCollectionResult(
+        raw_data=corrected_raw_data,
+        metadata=collection_result.metadata,
+        jitter_corrected=True,
+        jitter_rms_x=float(np.std(jitter_x)),
+        jitter_rms_y=float(np.std(jitter_y)),
+    )
+
+
+def get_jitter_rmat(
+    wire_name: str,
+    bpm_names: list[str],
+    beampath: str,
+    physics_model: str = "BLEM",
+    include_energy: bool = True,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Get R-matrices from wire to each BPM for orbit fitting.
+
+    Parameters
+    ----------
+    wire_name : str
+        Wire device name (MAD element name).
+    bpm_names : list[str]
+        BPM control names (e.g., ["BPMS:HTR:120", "BPMS:HTR:320"]).
+    beampath : str
+        Beam path identifier for the model.
+    physics_model : str
+        Model source. Default "BLEM".
+    include_energy : bool
+        If True, include R16/R36 dispersion term (3-column matrix).
+        If False, use only R11,R12 / R33,R34 (2-column matrix).
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray]
+        (rmat_x, rmat_y) where:
+        - rmat_x is [N_bpms x 2] (or [N_bpms x 3] with energy)
+        - rmat_y is [N_bpms x 2] (or [N_bpms x 3] with energy)
+        Each row relates BPM position reading to beam state at wire.
+    """
+    from meme.model import Model
+
+    model = Model(beampath, model_source=physics_model, use_design=False)
+
+    n_cols = 3 if include_energy else 2
+    rmat_x = np.zeros((len(bpm_names), n_cols))
+    rmat_y = np.zeros((len(bpm_names), n_cols))
+
+    for i, bpm_name in enumerate(bpm_names):
+        rmat_6x6 = model.get_rmat(from_device=wire_name, to_device=bpm_name)
+
+        # x plane: position at BPM from (x, x') at wire
+        rmat_x[i, 0] = rmat_6x6[0, 0]  # R11
+        rmat_x[i, 1] = rmat_6x6[0, 1]  # R12
+        if include_energy:
+            rmat_x[i, 2] = rmat_6x6[0, 5]  # R16
+
+        # y plane: position at BPM from (y, y') at wire
+        rmat_y[i, 0] = rmat_6x6[2, 2]  # R33
+        rmat_y[i, 1] = rmat_6x6[2, 3]  # R34
+        if include_energy:
+            rmat_y[i, 2] = rmat_6x6[2, 5]  # R36
+
+    return rmat_x, rmat_y
+
+
+def _extract_bpm_data(
+    raw_data: dict[str, np.ndarray],
+) -> tuple[np.ndarray, np.ndarray, list[str]]:
+    """Extract BPM x/y position data from raw_data dictionary.
+
+    Identifies BPM data by keys starting with 'BPM' and ending in ':X' / ':Y'.
+    The MAD device name is used as the BPM identifier.
+
+    Returns
+    -------
+    tuple
+        (bpm_x_array, bpm_y_array, bpm_names) where arrays are
+        [N_bpms x N_pulses] and bpm_names are MAD device names.
+    """
+    bpm_x_keys = sorted(k for k in raw_data if k.startswith("BPM") and k.endswith(":X"))
+
+    bpm_names = []
+    x_arrays = []
+    y_arrays = []
+
+    for x_key in bpm_x_keys:
+        name = x_key[:-2]  # Strip ':X'
+        y_key = f"{name}:Y"
+
+        if y_key not in raw_data:
+            continue
+
+        x_arr = raw_data[x_key]
+        y_arr = raw_data[y_key]
+
+        if x_arr is None or y_arr is None:
+            continue
+        if np.all(np.isnan(x_arr)) or np.all(np.isnan(y_arr)):
+            continue
+
+        bpm_names.append(name)
+        x_arrays.append(x_arr)
+        y_arrays.append(y_arr)
+
+    if not bpm_names:
+        raise ValueError("No valid BPM position data found in collection result.")
+
+    bpm_x_data = np.array(x_arrays)  # [N_bpms x N_pulses]
+    bpm_y_data = np.array(y_arrays)  # [N_bpms x N_pulses]
+
+    return bpm_x_data, bpm_y_data, bpm_names
+
+
+def _compute_orbit_fit(
+    bpm_x_data: np.ndarray,
+    bpm_y_data: np.ndarray,
+    rmat_x: np.ndarray,
+    rmat_y: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Compute beam position at wire from BPM readings via least-squares orbit fit.
+
+    Parameters
+    ----------
+    bpm_x_data : np.ndarray
+        BPM x positions [N_bpms x N_pulses] in mm.
+    bpm_y_data : np.ndarray
+        BPM y positions [N_bpms x N_pulses] in mm.
+    rmat_x : np.ndarray
+        X-plane transport matrix [N_bpms x 2 or 3].
+    rmat_y : np.ndarray
+        Y-plane transport matrix [N_bpms x 2 or 3].
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray]
+        (jitter_x, jitter_y) - reconstructed beam position jitter at wire
+        for each pulse, in um (matching wire position units).
+    """
+    # Compute deviations from mean (mm)
+    delta_x = bpm_x_data - bpm_x_data.mean(axis=1, keepdims=True)
+    delta_y = bpm_y_data - bpm_y_data.mean(axis=1, keepdims=True)
+
+    # Convert mm -> m for orbit fit
+    delta_x_m = delta_x * 1e-3
+    delta_y_m = delta_y * 1e-3
+
+    # Least-squares fit: rmat @ orbit = delta_bpm for each pulse
+    # orbit_x shape: [n_params x N_pulses], orbit_x[0] is x position at wire
+    orbit_x, _, _, _ = np.linalg.lstsq(rmat_x, delta_x_m, rcond=None)
+    orbit_y, _, _, _ = np.linalg.lstsq(rmat_y, delta_y_m, rcond=None)
+
+    # Position at wire (first element of orbit vector), convert m -> um
+    jitter_x_um = orbit_x[0, :] * 1e6
+    jitter_y_um = orbit_y[0, :] * 1e6
+
+    return jitter_x_um, jitter_y_um

--- a/slac_measurements/wires/scan.py
+++ b/slac_measurements/wires/scan.py
@@ -24,6 +24,7 @@ class WireBeamProfileMeasurement(slac_measurements.beam_profile.BeamProfileMeasu
         scan_mode: ScanMode = "otf",
         fitting_method: FittingMethod = "gaussian",
         rms_detector: Optional[str] = None,
+        jitter_correction: bool = False,
     ) -> WireMeasurementAnalysisResult:
         """
         Run a wire scan and return the analyzed result.
@@ -33,6 +34,8 @@ class WireBeamProfileMeasurement(slac_measurements.beam_profile.BeamProfileMeasu
         scan_mode : "otf" (default) or "step".
         fitting_method : "gaussian" (default), "asymmetric_gaussian", or "super_gaussian".
         rms_detector : Detector for RMS sizes; defaults to the collection metadata default.
+        jitter_correction : If True, apply orbit-fit jitter correction before analysis.
+            Requires jitter_correction_bpms defined in wire metadata.
         """
 
         collection = create_wire_collection(
@@ -41,6 +44,14 @@ class WireBeamProfileMeasurement(slac_measurements.beam_profile.BeamProfileMeasu
             beampath=self.beampath,
         )
         self.collection_result = collection.measure()
+
+        if jitter_correction:
+            from slac_measurements.wires.jitter_correction import correct_jitter
+
+            self.collection_result = correct_jitter(
+                self.collection_result, beampath=self.beampath
+            )
+
         analysis = WireMeasurementAnalysis(
             collection_result=self.collection_result,
             fitting_method=fitting_method,


### PR DESCRIPTION
Jitter correction reconstructs the beam's pulse-to-pulse position jitter at the wire location and subtracts it from the measured wire positions before analysis. This removes orbit noise from the beam profile measurement, yielding a cleaner size estimate.

**The Math**
For each pulse in a wire scan, we have simultaneous BPM readings from multiple BPMs along the beamline. The algorithm:

- Centroid subtraction — For each BPM, subtract the mean position across all pulses to get pulse-to-pulse deviations (Δx, Δy).
- Orbit reconstruction via least-squares — Using the R-matrices (from `meme`) that relate the wire location to each BPM, solve the inverse transport problem: given the observed BPM deviations, reconstruct the beam position and angle at the wire. This is a least-squares fit (`np.linalg.lstsq`) of R @ [position, angle, (energy)]ᵀ = Δ_bpm using all available BPMs simultaneously.
- Projection onto stage axis — The reconstructed x/y beam jitter is projected onto the wire's stage direction using the install angle: `jitter_stage = jitter_x * sin(θ) + jitter_y * cos(θ)`.
- Subtraction — The projected jitter is subtracted from the raw wire positions, pulse by pulse.
- At least 2 BPMs with valid data are required for the fit.

**Code Changes**
Coordinate transformations pulled into a reusable module (`wires/coordinates.py`)
- Provides `stage_to_beam`, `beam_to_stage`, `xy_to_stage`, and `wire_angle_scales`
- Used by both analysis and jitter correction — no duplicated trig

Data collection now instantiates jitter BPMs (`wires/collection.py`)
- If `jitter_correction_bpms` is defined in the wire's metadata, collection automatically instantiates each BPM device
- Each BPM's X and Y buffer data is gathered using a "`bpm_buffer`" collection method key, which the data collection loop translates into calls to `device.x_buffer()` and `device.y_buffer()`

New attributes on the collection result (`wires/collection_results.py`)
- `jitter_corrected: bool` — set to `True` after correction runs
- `jitter_rms_x`, `jitter_rms_y` — RMS of the reconstructed jitter

Jitter correction sits between collection and analysis (`wires/scan.py`)
- The pipeline is: collect → correct jitter → analyze
- Correction produces a new `WireMeasurementCollectionResult` with adjusted positions; analysis proceeds as normal on the corrected data

User-facing API (`wires/scan.py`)
- Pass `jitter_correction=True` to `WireBeamProfileMeasurement.measure()` (or via the scan factory) to enable it
- Requires that `jitter_correction_bpms` is populated in the wire metadata for the device being scanned