### PR TITLE
Wire Scan jitter correction

### DIFF
--- a/slac_measurements/wires/__init__.py
+++ b/slac_measurements/wires/__init__.py
@@ -22,5 +22,5 @@ from slac_measurements.wires.collection_results import (
 # Collection factory and mode type — for advanced users constructing collections directly
 from slac_measurements.wires.collection import ScanMode, create_wire_collection
 
-# Jitter correction — optional post-collection processing
-from slac_measurements.wires.jitter_correction import correct_jitter
+# Jitter correction — compute beam jitter from BPM data
+from slac_measurements.wires.jitter_correction import compute_jitter

--- a/slac_measurements/wires/__init__.py
+++ b/slac_measurements/wires/__init__.py
@@ -21,3 +21,6 @@ from slac_measurements.wires.collection_results import (
 
 # Collection factory and mode type — for advanced users constructing collections directly
 from slac_measurements.wires.collection import ScanMode, create_wire_collection
+
+# Jitter correction — optional post-collection processing
+from slac_measurements.wires.jitter_correction import correct_jitter

--- a/slac_measurements/wires/analysis.py
+++ b/slac_measurements/wires/analysis.py
@@ -89,6 +89,7 @@ class WireMeasurementAnalysis(slac_measurements.beam_profile.BeamProfileAnalysis
             collection_result=self.collection_result,
             metadata=metadata,
             profiles=profile_measurements,
+            fitting_method=self.fitting_method,
             jitter_corrected=jitter_correction,
         )
 

--- a/slac_measurements/wires/analysis.py
+++ b/slac_measurements/wires/analysis.py
@@ -8,6 +8,7 @@ from typing import Literal
 
 import slac_measurements.beam_profile
 from slac_measurements.wires.coordinates import stage_to_beam, beam_to_stage
+from slac_measurements.wires.jitter_correction import compute_jitter
 from slac_measurements.wires.analysis_results import (
     DetectorFit,
     DetectorProfileMeasurement,
@@ -63,8 +64,6 @@ class WireMeasurementAnalysis(slac_measurements.beam_profile.BeamProfileAnalysis
         """
 
         if jitter_correction:
-            from slac_measurements.wires.jitter_correction import compute_jitter
-
             beampath = self.collection_result.metadata.beampath
             self._jitter_x, self._jitter_y = compute_jitter(
                 self.collection_result, beampath, physics_model

--- a/slac_measurements/wires/analysis.py
+++ b/slac_measurements/wires/analysis.py
@@ -83,6 +83,13 @@ class WireMeasurementAnalysis(slac_measurements.beam_profile.BeamProfileAnalysis
             rms_detector if rms_detector is not None else metadata.default_detector
         )
 
+        jitter_rms = None
+        if jitter_correction and self._jitter_x is not None:
+            jitter_rms = (
+                float(np.std(self._jitter_x)),
+                float(np.std(self._jitter_y)),
+            )
+
         return WireMeasurementAnalysisResult(
             fit_result=fit_result,
             rms_sizes=rms_sizes,
@@ -91,6 +98,7 @@ class WireMeasurementAnalysis(slac_measurements.beam_profile.BeamProfileAnalysis
             profiles=profile_measurements,
             fitting_method=self.fitting_method,
             jitter_corrected=jitter_correction,
+            jitter_rms=jitter_rms,
         )
 
     def _create_detector_measurement(

--- a/slac_measurements/wires/analysis.py
+++ b/slac_measurements/wires/analysis.py
@@ -7,6 +7,7 @@ import warnings
 from typing import Literal
 
 import slac_measurements.beam_profile
+from slac_measurements.wires.coordinates import stage_to_beam, beam_to_stage
 from slac_measurements.wires.analysis_results import (
     DetectorFit,
     DetectorProfileMeasurement,
@@ -109,13 +110,9 @@ class WireMeasurementAnalysis(slac_measurements.beam_profile.BeamProfileAnalysis
             profile: str, positions: np.ndarray
         ) -> np.ndarray:
             """Convert stage positions to beam coordinates for a given profile."""
-            scale = _extract_wire_angle()
-            return positions * abs(scale[profile])
-
-        def _extract_wire_angle() -> dict:
-            """Extract the wire install angle (in radians) for coordinate conversion."""
-            rad = np.deg2rad(self.collection_result.metadata.install_angle)
-            return {"x": np.sin(rad), "y": np.cos(rad), "u": 1.0}
+            return stage_to_beam(
+                positions, profile, self.collection_result.metadata.install_angle
+            )
 
         def _fit_detector_in_profile(
             x_beam: np.ndarray, detector_signal: np.ndarray, profile: str
@@ -137,8 +134,9 @@ class WireMeasurementAnalysis(slac_measurements.beam_profile.BeamProfileAnalysis
                 fp = fitting_module.fit(pos=peak_window[0], data=peak_window[1])
 
             # Convert mean from beam coordinates back to stage coordinates
-            scale = _extract_wire_angle()
-            mean_stage = fp["mean"] / abs(scale[profile])
+            mean_stage = beam_to_stage(
+                fp["mean"], profile, self.collection_result.metadata.install_angle
+            )
 
             # Generate fit curve (in beam coordinates)
             # Build kwargs dynamically to handle different fit types

--- a/slac_measurements/wires/analysis.py
+++ b/slac_measurements/wires/analysis.py
@@ -40,7 +40,6 @@ class WireMeasurementAnalysis(slac_measurements.beam_profile.BeamProfileAnalysis
         self,
         rms_detector: str | None = None,
         jitter_correction: bool = False,
-        beampath: str | None = None,
         physics_model: str = "BLEM",
         include_energy: bool = True,
     ) -> WireMeasurementAnalysisResult:
@@ -55,9 +54,6 @@ class WireMeasurementAnalysis(slac_measurements.beam_profile.BeamProfileAnalysis
         jitter_correction : bool
             If True, compute orbit-fit jitter correction from BPM data
             and subtract per-profile in beam coordinates before fitting.
-        beampath : str, optional
-            Beam path identifier for R-matrix retrieval. Required when
-            jitter_correction is True.
         physics_model : str
             Model source for R-matrix retrieval. Default "BLEM".
         include_energy : bool
@@ -72,8 +68,7 @@ class WireMeasurementAnalysis(slac_measurements.beam_profile.BeamProfileAnalysis
         if jitter_correction:
             from slac_measurements.wires.jitter_correction import compute_jitter
 
-            if beampath is None:
-                raise ValueError("beampath is required when jitter_correction is True.")
+            beampath = self.collection_result.metadata.beampath
             self._jitter_x, self._jitter_y = compute_jitter(
                 self.collection_result, beampath, physics_model, include_energy
             )

--- a/slac_measurements/wires/analysis.py
+++ b/slac_measurements/wires/analysis.py
@@ -41,7 +41,6 @@ class WireMeasurementAnalysis(slac_measurements.beam_profile.BeamProfileAnalysis
         rms_detector: str | None = None,
         jitter_correction: bool = False,
         physics_model: str = "BLEM",
-        include_energy: bool = True,
     ) -> WireMeasurementAnalysisResult:
         """
         Fit profiles and extract RMS beam sizes.
@@ -56,8 +55,6 @@ class WireMeasurementAnalysis(slac_measurements.beam_profile.BeamProfileAnalysis
             and subtract per-profile in beam coordinates before fitting.
         physics_model : str
             Model source for R-matrix retrieval. Default "BLEM".
-        include_energy : bool
-            Whether to include the dispersion term in the orbit fit.
 
         Returns
         -------
@@ -70,7 +67,7 @@ class WireMeasurementAnalysis(slac_measurements.beam_profile.BeamProfileAnalysis
 
             beampath = self.collection_result.metadata.beampath
             self._jitter_x, self._jitter_y = compute_jitter(
-                self.collection_result, beampath, physics_model, include_energy
+                self.collection_result, beampath, physics_model
             )
 
         profile_indices = self._get_profile_range_indices()

--- a/slac_measurements/wires/analysis.py
+++ b/slac_measurements/wires/analysis.py
@@ -33,8 +33,17 @@ class WireMeasurementAnalysis(slac_measurements.beam_profile.BeamProfileAnalysis
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
     fitting_method: FittingMethod = "gaussian"
+    _jitter_x: np.ndarray | None = None
+    _jitter_y: np.ndarray | None = None
 
-    def analyze(self, rms_detector: str | None = None) -> WireMeasurementAnalysisResult:
+    def analyze(
+        self,
+        rms_detector: str | None = None,
+        jitter_correction: bool = False,
+        beampath: str | None = None,
+        physics_model: str = "BLEM",
+        include_energy: bool = True,
+    ) -> WireMeasurementAnalysisResult:
         """
         Fit profiles and extract RMS beam sizes.
 
@@ -43,12 +52,31 @@ class WireMeasurementAnalysis(slac_measurements.beam_profile.BeamProfileAnalysis
         rms_detector : str, optional
             Detector used for RMS extraction; defaults to
             ``collection_result.metadata.default_detector``.
+        jitter_correction : bool
+            If True, compute orbit-fit jitter correction from BPM data
+            and subtract per-profile in beam coordinates before fitting.
+        beampath : str, optional
+            Beam path identifier for R-matrix retrieval. Required when
+            jitter_correction is True.
+        physics_model : str
+            Model source for R-matrix retrieval. Default "BLEM".
+        include_energy : bool
+            Whether to include the dispersion term in the orbit fit.
 
         Returns
         -------
         WireMeasurementAnalysisResult
             Fit results, RMS sizes, and organized profile data.
         """
+
+        if jitter_correction:
+            from slac_measurements.wires.jitter_correction import compute_jitter
+
+            if beampath is None:
+                raise ValueError("beampath is required when jitter_correction is True.")
+            self._jitter_x, self._jitter_y = compute_jitter(
+                self.collection_result, beampath, physics_model, include_energy
+            )
 
         profile_indices = self._get_profile_range_indices()
         profile_measurements = self._organize_data_by_profile(profile_indices)
@@ -69,6 +97,7 @@ class WireMeasurementAnalysis(slac_measurements.beam_profile.BeamProfileAnalysis
             collection_result=self.collection_result,
             metadata=metadata,
             profiles=profile_measurements,
+            jitter_corrected=jitter_correction,
         )
 
     def _create_detector_measurement(
@@ -211,6 +240,11 @@ class WireMeasurementAnalysis(slac_measurements.beam_profile.BeamProfileAnalysis
         x_stage = profile_data.positions
         x_beam = _convert_stage_to_beam_coords(profile, x_stage)
 
+        if self._jitter_x is not None:
+            x_beam = self._apply_jitter_correction(
+                x_beam, profile, profile_data.profile_indices
+            )
+
         detector_fits = {}
         for detector_name in detectors:
             if detector_name not in profile_data.detectors:
@@ -221,6 +255,30 @@ class WireMeasurementAnalysis(slac_measurements.beam_profile.BeamProfileAnalysis
             )
 
         return FitResult(detectors=detector_fits)
+
+    def _apply_jitter_correction(
+        self, x_beam: np.ndarray, profile: str, indices: np.ndarray
+    ) -> np.ndarray:
+        """Subtract per-pulse beam jitter in beam coordinates.
+
+        Matches the legacy MATLAB behavior: jitter is subtracted after
+        stage-to-beam conversion, so x-profile subtracts jitter_x and
+        y-profile subtracts jitter_y directly in beam-space (um).
+        """
+        if self._jitter_x is None or self._jitter_y is None:
+            return x_beam
+
+        jx = self._jitter_x[indices]
+        jy = self._jitter_y[indices]
+
+        if profile == "x":
+            return x_beam - jx
+        elif profile == "y":
+            return x_beam - jy
+        else:
+            install_angle = self.collection_result.metadata.install_angle
+            rad = np.radians(install_angle)
+            return x_beam - (jx * np.sin(rad) + jy * np.cos(rad))
 
     @staticmethod
     def _get_monotonic_indices(

--- a/slac_measurements/wires/analysis.py
+++ b/slac_measurements/wires/analysis.py
@@ -1,6 +1,6 @@
 import importlib
 import numpy as np
-from pydantic import ConfigDict
+from pydantic import ConfigDict, PrivateAttr
 from scipy.ndimage import median_filter
 from skimage.filters import threshold_triangle
 import warnings
@@ -33,8 +33,8 @@ class WireMeasurementAnalysis(slac_measurements.beam_profile.BeamProfileAnalysis
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
     fitting_method: FittingMethod = "gaussian"
-    _jitter_x: np.ndarray | None = None
-    _jitter_y: np.ndarray | None = None
+    _jitter_x: np.ndarray | None = PrivateAttr(default=None)
+    _jitter_y: np.ndarray | None = PrivateAttr(default=None)
 
     def analyze(
         self,

--- a/slac_measurements/wires/analysis_results.py
+++ b/slac_measurements/wires/analysis_results.py
@@ -50,44 +50,45 @@ class WireMeasurementAnalysisResult(BeamProfileMeasurementResult):
     profiles: dict[str, ProfileMeasurement]
     jitter_corrected: bool = False
 
-    def set_rms_detector(self, detector: str | None = None) -> None:
-        """Mutate the result to use a different detector for RMS sizes.
+    def reanalyze(
+        self,
+        jitter_correction: bool = False,
+        fitting_method: str | None = None,
+        rms_detector: str | None = None,
+        physics_model: str = "BLEM",
+    ) -> "WireMeasurementAnalysisResult":
+        """Re-analyze the collected data with different settings.
 
         Parameters
         ----------
-        detector : str, optional
-            Detector name used to derive ``rms_sizes``. If omitted, the
-            metadata ``default_detector`` is used.
+        jitter_correction : bool
+            If True, apply orbit-fit jitter correction.
+        fitting_method : str, optional
+            Override fitting method. If None, uses the same as the
+            original analysis.
+        rms_detector : str, optional
+            Override detector for RMS sizes.
+        physics_model : str
+            Model source for R-matrix retrieval. Default "BLEM".
+
+        Returns
+        -------
+        WireMeasurementAnalysisResult
+            New analysis result from the same raw collection data.
         """
+        from slac_measurements.wires.analysis import WireMeasurementAnalysis
 
-        metadata = self.collection_result.metadata
-        selected_detector = metadata.default_detector if detector is None else detector
+        method = fitting_method if fitting_method is not None else "gaussian"
 
-        if selected_detector not in metadata.detectors:
-            raise ValueError(
-                f"Detector '{selected_detector}' is not available in "
-                f"metadata.detectors={metadata.detectors}."
-            )
-
-        x_rms = self._get_profile_rms(profile="x", detector=selected_detector)
-        y_rms = self._get_profile_rms(profile="y", detector=selected_detector)
-
-        self.rms_sizes = np.array([x_rms, y_rms], dtype=object)
-        self.metadata.rms_detector = selected_detector
-        self.collection_result.metadata.rms_detector = selected_detector
-
-    def _get_profile_rms(self, profile: str, detector: str) -> float | None:
-        """Return the RMS size for a profile/detector pair, if present."""
-        if profile not in self.fit_result:
-            return None
-
-        if detector not in self.fit_result[profile].detectors:
-            raise ValueError(
-                f"Detector '{detector}' is not available in fit_result "
-                f"for profile '{profile}'."
-            )
-
-        return self.fit_result[profile].detectors[detector].sigma
+        analysis = WireMeasurementAnalysis(
+            collection_result=self.collection_result,
+            fitting_method=method,
+        )
+        return analysis.analyze(
+            rms_detector=rms_detector,
+            jitter_correction=jitter_correction,
+            physics_model=physics_model,
+        )
 
     def __repr__(self) -> str:
         """Return a compact string representation of the analysis result."""

--- a/slac_measurements/wires/analysis_results.py
+++ b/slac_measurements/wires/analysis_results.py
@@ -2,7 +2,6 @@ import numpy as np
 
 from pydantic import BaseModel, ConfigDict
 
-from slac_measurements.wires.analysis import WireMeasurementAnalysis
 from slac_measurements.beam_profile import (
     BeamProfileMeasurementResult,
 )
@@ -78,6 +77,8 @@ class WireMeasurementAnalysisResult(BeamProfileMeasurementResult):
         WireMeasurementAnalysisResult
             New analysis result from the same raw collection data.
         """
+        from slac_measurements.wires.analysis import WireMeasurementAnalysis
+
         analysis = WireMeasurementAnalysis(
             collection_result=self.collection_result,
             fitting_method=fitting_method,

--- a/slac_measurements/wires/analysis_results.py
+++ b/slac_measurements/wires/analysis_results.py
@@ -103,6 +103,7 @@ class WireMeasurementAnalysisResult(BeamProfileMeasurementResult):
             f"beampath='{meta.beampath}', "
             f"rms_sizes={rms_sizes_repr}, "
             f"rms_detector='{meta.rms_detector}', "
+            f"jitter_corrected={self.jitter_corrected}, "
             f"profiles={profile_count}, "
             f"fit_profiles={fit_profile_count}, "
             f"detectors={detector_count}, "

--- a/slac_measurements/wires/analysis_results.py
+++ b/slac_measurements/wires/analysis_results.py
@@ -48,12 +48,13 @@ class WireMeasurementAnalysisResult(BeamProfileMeasurementResult):
     fit_result: dict[str, FitResult]
     collection_result: WireMeasurementCollectionResult
     profiles: dict[str, ProfileMeasurement]
+    fitting_method: str = "gaussian"
     jitter_corrected: bool = False
 
     def reanalyze(
         self,
         jitter_correction: bool = False,
-        fitting_method: str | None = None,
+        fitting_method: str = "gaussian",
         rms_detector: str | None = None,
         physics_model: str = "BLEM",
     ) -> "WireMeasurementAnalysisResult":
@@ -63,9 +64,8 @@ class WireMeasurementAnalysisResult(BeamProfileMeasurementResult):
         ----------
         jitter_correction : bool
             If True, apply orbit-fit jitter correction.
-        fitting_method : str, optional
-            Override fitting method. If None, uses the same as the
-            original analysis.
+        fitting_method : str
+            Fitting method to use. Default "gaussian".
         rms_detector : str, optional
             Override detector for RMS sizes.
         physics_model : str
@@ -78,11 +78,9 @@ class WireMeasurementAnalysisResult(BeamProfileMeasurementResult):
         """
         from slac_measurements.wires.analysis import WireMeasurementAnalysis
 
-        method = fitting_method if fitting_method is not None else "gaussian"
-
         analysis = WireMeasurementAnalysis(
             collection_result=self.collection_result,
-            fitting_method=method,
+            fitting_method=fitting_method,
         )
         return analysis.analyze(
             rms_detector=rms_detector,
@@ -104,6 +102,7 @@ class WireMeasurementAnalysisResult(BeamProfileMeasurementResult):
             f"beampath='{meta.beampath}', "
             f"rms_sizes={rms_sizes_repr}, "
             f"rms_detector='{meta.rms_detector}', "
+            f"fitting_method='{self.fitting_method}', "
             f"jitter_corrected={self.jitter_corrected}, "
             f"profiles={profile_count}, "
             f"fit_profiles={fit_profile_count}, "

--- a/slac_measurements/wires/analysis_results.py
+++ b/slac_measurements/wires/analysis_results.py
@@ -48,6 +48,7 @@ class WireMeasurementAnalysisResult(BeamProfileMeasurementResult):
     fit_result: dict[str, FitResult]
     collection_result: WireMeasurementCollectionResult
     profiles: dict[str, ProfileMeasurement]
+    jitter_corrected: bool = False
 
     def set_rms_detector(self, detector: str | None = None) -> None:
         """Mutate the result to use a different detector for RMS sizes.

--- a/slac_measurements/wires/analysis_results.py
+++ b/slac_measurements/wires/analysis_results.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from pydantic import BaseModel, ConfigDict
 
+from slac_measurements.wires.analysis import WireMeasurementAnalysis
 from slac_measurements.beam_profile import (
     BeamProfileMeasurementResult,
 )
@@ -77,8 +78,6 @@ class WireMeasurementAnalysisResult(BeamProfileMeasurementResult):
         WireMeasurementAnalysisResult
             New analysis result from the same raw collection data.
         """
-        from slac_measurements.wires.analysis import WireMeasurementAnalysis
-
         analysis = WireMeasurementAnalysis(
             collection_result=self.collection_result,
             fitting_method=fitting_method,

--- a/slac_measurements/wires/analysis_results.py
+++ b/slac_measurements/wires/analysis_results.py
@@ -105,6 +105,7 @@ class WireMeasurementAnalysisResult(BeamProfileMeasurementResult):
             f"rms_detector='{meta.rms_detector}', "
             f"fitting_method='{self.fitting_method}', "
             f"jitter_corrected={self.jitter_corrected}, "
+            f"jitter_rms={self.jitter_rms}, "
             f"profiles={profile_count}, "
             f"fit_profiles={fit_profile_count}, "
             f"detectors={detector_count}, "

--- a/slac_measurements/wires/analysis_results.py
+++ b/slac_measurements/wires/analysis_results.py
@@ -50,6 +50,7 @@ class WireMeasurementAnalysisResult(BeamProfileMeasurementResult):
     profiles: dict[str, ProfileMeasurement]
     fitting_method: str = "gaussian"
     jitter_corrected: bool = False
+    jitter_rms: tuple[float, float] | None = None
 
     def reanalyze(
         self,

--- a/slac_measurements/wires/collection.py
+++ b/slac_measurements/wires/collection.py
@@ -2,7 +2,9 @@ import logging
 from abc import ABC, abstractmethod
 from datetime import datetime
 from pathlib import Path
-from typing import Literal, Self
+from typing import Literal
+
+from typing_extensions import Self
 
 from pydantic import model_validator
 from slac_devices.wire import Wire

--- a/slac_measurements/wires/collection.py
+++ b/slac_measurements/wires/collection.py
@@ -157,7 +157,7 @@ class BaseWireMeasurementCollection(
                 devices[name] = detector
 
         # Add jitter correction BPMs if defined
-        jitter_bpm_names = self.beam_profile_device.metadata.jitter_correction_bpms
+        jitter_bpm_names = self.beam_profile_device.metadata.jitter_bpms
         if jitter_bpm_names:
             area = self.beam_profile_device.area
             for name in jitter_bpm_names:

--- a/slac_measurements/wires/collection.py
+++ b/slac_measurements/wires/collection.py
@@ -2,16 +2,11 @@ import logging
 from abc import ABC, abstractmethod
 from datetime import datetime
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Self
 
-import numpy as np
 from pydantic import model_validator
-from typing_extensions import Self
-
 from slac_devices.wire import Wire
 import slac_measurements.beam_profile
-import slac_measurements.wires.buffer
-import slac_measurements.utils
 from slac_measurements.wires.collection_results import (
     MeasurementMetadata,
     WireMeasurementCollectionResult,
@@ -50,6 +45,7 @@ class BaseWireMeasurementCollection(
     data: dict | None = None
     logger: logging.Logger | None = None
     metadata: MeasurementMetadata | None = None
+    jitter_bpms: bool = False
 
     def measure(self) -> WireMeasurementCollectionResult:
         """
@@ -126,6 +122,7 @@ class BaseWireMeasurementCollection(
             create_by_prefix = {
                 "LBLM": slac_devices.reader.create_lblm,
                 "PMT": slac_devices.reader.create_pmt,
+                "BPM": slac_devices.reader.create_bpm,
             }
 
             creator = next(
@@ -156,6 +153,16 @@ class BaseWireMeasurementCollection(
             detector = _instantiate_device(name, area)
             if detector is not None:
                 devices[name] = detector
+
+        # Add jitter correction BPMs if defined
+        jitter_bpm_names = self.beam_profile_device.metadata.jitter_correction_bpms
+        if jitter_bpm_names:
+            area = self.beam_profile_device.area
+            for name in jitter_bpm_names:
+                bpm = _instantiate_device(name, area)
+                if bpm is not None:
+                    devices[name] = bpm
+            self.jitter_bpms = True
 
         self.logger.info("Device dictionary built.")
         return devices
@@ -206,6 +213,8 @@ class BaseWireMeasurementCollection(
     def _get_data_from_buffer(self) -> dict:
         """Collects wire scan and detector data after buffer completes."""
 
+        import slac_measurements.utils
+
         def _get_buffer_collection_method(device_name: str) -> str | None:
             """Determine the buffer collection method for a given device based on its name."""
 
@@ -215,26 +224,41 @@ class BaseWireMeasurementCollection(
                 return "fast_buffer"
             elif device_name.startswith("PMT"):
                 return "qdcraw_buffer"
+            elif device_name.startswith("BPM"):
+                return "bpm"
             else:
                 return None
 
-        def _collect_device_data(device_name: str) -> np.ndarray:
-            """Collect data for a given device using the appropriate method."""
+        def _collect_device_data(device_name: str, data: dict) -> None:
+            """Collect data for a given device and add to data dict."""
 
             device = self.devices[device_name]
             buffer_method = _get_buffer_collection_method(device_name)
 
             if buffer_method is None:
-                return (
-                    device.measure()
-                )  # For devices like TMITLOSS that don't use buffer collection
+                data[device_name] = device.measure()
+                return
 
-            return slac_measurements.utils.collect_with_size_check(
+            if buffer_method == "bpm":
+                x_data = slac_measurements.utils.collect_with_size_check(
+                    device, "x_buffer", self.my_buffer, self.logger
+                )
+                y_data = slac_measurements.utils.collect_with_size_check(
+                    device, "y_buffer", self.my_buffer, self.logger
+                )
+                data[f"{device_name}:X"] = x_data
+                data[f"{device_name}:Y"] = y_data
+                return
+
+            data[device_name] = slac_measurements.utils.collect_with_size_check(
                 device, buffer_method, self.my_buffer, self.logger
             )
 
         self.logger.info("Getting data from timing buffer ...")
-        data = {name: _collect_device_data(name) for name in self.devices.keys()}
+        data = {}
+        for name in self.devices:
+            _collect_device_data(name, data)
+
         self.logger.info("Data retrieved from buffer. Scan complete.")
         return data
 

--- a/slac_measurements/wires/collection.py
+++ b/slac_measurements/wires/collection.py
@@ -47,7 +47,6 @@ class BaseWireMeasurementCollection(
     data: dict | None = None
     logger: logging.Logger | None = None
     metadata: MeasurementMetadata | None = None
-    jitter_bpms: bool = False
 
     def measure(self) -> WireMeasurementCollectionResult:
         """
@@ -163,7 +162,6 @@ class BaseWireMeasurementCollection(
                 bpm = _instantiate_device(name, area)
                 if bpm is not None:
                     devices[name] = bpm
-            self.jitter_bpms = True
 
         self.logger.info("Device dictionary built.")
         return devices

--- a/slac_measurements/wires/collection.py
+++ b/slac_measurements/wires/collection.py
@@ -224,7 +224,7 @@ class BaseWireMeasurementCollection(
             elif device_name.startswith("PMT"):
                 return "qdcraw_buffer"
             elif device_name.startswith("BPM"):
-                return "bpm"
+                return "bpm_buffer"
             else:
                 return None
 
@@ -236,6 +236,12 @@ class BaseWireMeasurementCollection(
 
             if buffer_method is None:
                 return device.measure()
+
+            if buffer_method == "bpm_buffer":
+                return {
+                    "x": device.x_buffer(self.buffer, retries=3, retry_delay=3.0),
+                    "y": device.y_buffer(self.buffer, retries=3, retry_delay=3.0),
+                }
 
             return getattr(device, buffer_method)(
                 self.buffer, retries=3, retry_delay=3.0

--- a/slac_measurements/wires/collection_results.py
+++ b/slac_measurements/wires/collection_results.py
@@ -41,6 +41,9 @@ class WireMeasurementCollectionResult(BeamProfileCollectionResult):
     model_config = ConfigDict(arbitrary_types_allowed=True)
     raw_data: dict[str, Any]
     metadata: MeasurementMetadata
+    jitter_corrected: bool = False
+    jitter_rms_x: float | None = None
+    jitter_rms_y: float | None = None
 
     def __repr__(self) -> str:
         """Return a string representation of the WireMeasurementCollectionResult."""
@@ -76,6 +79,13 @@ class WireMeasurementCollectionResult(BeamProfileCollectionResult):
             # Save raw data
             raw_data_group = f.create_group("raw_data")
             self._save_raw_data(raw_data_group)
+
+            # Save jitter correction info
+            f.attrs["jitter_corrected"] = self.jitter_corrected
+            if self.jitter_rms_x is not None:
+                f.attrs["jitter_rms_x"] = self.jitter_rms_x
+            if self.jitter_rms_y is not None:
+                f.attrs["jitter_rms_y"] = self.jitter_rms_y
 
     def _save_metadata(self, group: h5py.Group) -> None:
         """Save measurement metadata as HDF5 attributes and datasets."""
@@ -152,9 +162,17 @@ def load_from_h5(filepath: str) -> WireMeasurementCollectionResult:
         # Load raw data
         raw_data = _load_raw_data(f["raw_data"])
 
+        # Load jitter correction info
+        jitter_corrected = bool(f.attrs.get("jitter_corrected", False))
+        jitter_rms_x = f.attrs.get("jitter_rms_x", None)
+        jitter_rms_y = f.attrs.get("jitter_rms_y", None)
+
     return WireMeasurementCollectionResult(
         raw_data=raw_data,
         metadata=metadata,
+        jitter_corrected=jitter_corrected,
+        jitter_rms_x=float(jitter_rms_x) if jitter_rms_x is not None else None,
+        jitter_rms_y=float(jitter_rms_y) if jitter_rms_y is not None else None,
     )
 
 

--- a/slac_measurements/wires/collection_results.py
+++ b/slac_measurements/wires/collection_results.py
@@ -41,9 +41,6 @@ class WireMeasurementCollectionResult(BeamProfileCollectionResult):
     model_config = ConfigDict(arbitrary_types_allowed=True)
     raw_data: dict[str, Any]
     metadata: MeasurementMetadata
-    jitter_corrected: bool = False
-    jitter_rms_x: float | None = None
-    jitter_rms_y: float | None = None
 
     def __repr__(self) -> str:
         """Return a string representation of the WireMeasurementCollectionResult."""
@@ -79,13 +76,6 @@ class WireMeasurementCollectionResult(BeamProfileCollectionResult):
             # Save raw data
             raw_data_group = f.create_group("raw_data")
             self._save_raw_data(raw_data_group)
-
-            # Save jitter correction info
-            f.attrs["jitter_corrected"] = self.jitter_corrected
-            if self.jitter_rms_x is not None:
-                f.attrs["jitter_rms_x"] = self.jitter_rms_x
-            if self.jitter_rms_y is not None:
-                f.attrs["jitter_rms_y"] = self.jitter_rms_y
 
     def _save_metadata(self, group: h5py.Group) -> None:
         """Save measurement metadata as HDF5 attributes and datasets."""
@@ -162,17 +152,9 @@ def load_from_h5(filepath: str) -> WireMeasurementCollectionResult:
         # Load raw data
         raw_data = _load_raw_data(f["raw_data"])
 
-        # Load jitter correction info
-        jitter_corrected = bool(f.attrs.get("jitter_corrected", False))
-        jitter_rms_x = f.attrs.get("jitter_rms_x", None)
-        jitter_rms_y = f.attrs.get("jitter_rms_y", None)
-
     return WireMeasurementCollectionResult(
         raw_data=raw_data,
         metadata=metadata,
-        jitter_corrected=jitter_corrected,
-        jitter_rms_x=float(jitter_rms_x) if jitter_rms_x is not None else None,
-        jitter_rms_y=float(jitter_rms_y) if jitter_rms_y is not None else None,
     )
 
 

--- a/slac_measurements/wires/coordinates.py
+++ b/slac_measurements/wires/coordinates.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+
+def wire_angle_scales(install_angle_deg: float) -> dict[str, float]:
+    """Scale factors for converting between stage and beam coordinates.
+
+    Parameters
+    ----------
+    install_angle_deg : float
+        Wire installation angle in degrees.
+
+    Returns
+    -------
+    dict[str, float]
+        {"x": sin(angle), "y": cos(angle), "u": 1.0}
+    """
+    rad = np.radians(install_angle_deg)
+    return {"x": np.sin(rad), "y": np.cos(rad), "u": 1.0}
+
+
+def stage_to_beam(
+    positions: np.ndarray, profile: str, install_angle_deg: float
+) -> np.ndarray:
+    """Convert wire stage positions to beam coordinates for a profile."""
+    scales = wire_angle_scales(install_angle_deg)
+    return positions * abs(scales[profile])
+
+
+def beam_to_stage(
+    positions: np.ndarray, profile: str, install_angle_deg: float
+) -> np.ndarray:
+    """Convert beam coordinates back to wire stage positions for a profile."""
+    scales = wire_angle_scales(install_angle_deg)
+    return positions / abs(scales[profile])
+
+
+def xy_to_stage(
+    jitter_x: np.ndarray, jitter_y: np.ndarray, install_angle_deg: float
+) -> np.ndarray:
+    """Project x/y beam jitter onto the wire stage direction."""
+    scales = wire_angle_scales(install_angle_deg)
+    return jitter_x * scales["x"] + jitter_y * scales["y"]

--- a/slac_measurements/wires/jitter_correction.py
+++ b/slac_measurements/wires/jitter_correction.py
@@ -88,7 +88,7 @@ def get_jitter_rmat(
     wire_name : str
         Wire device name (MAD element name).
     bpm_names : list[str]
-        BPM control names (e.g., ["BPMS:HTR:120", "BPMS:HTR:320"]).
+        BPM element names (MAD names, e.g., ["BPM10", "BPM11"]).
     beampath : str
         Beam path identifier for the model.
     physics_model : str

--- a/slac_measurements/wires/jitter_correction.py
+++ b/slac_measurements/wires/jitter_correction.py
@@ -1,20 +1,18 @@
 import numpy as np
 
 from slac_measurements.wires.collection_results import WireMeasurementCollectionResult
-from slac_measurements.wires.coordinates import xy_to_stage
 
 
-def correct_jitter(
+def compute_jitter(
     collection_result: WireMeasurementCollectionResult,
     beampath: str,
     physics_model: str = "BLEM",
     include_energy: bool = True,
-) -> WireMeasurementCollectionResult:
-    """Apply jitter correction to a wire scan collection result.
+) -> tuple[np.ndarray, np.ndarray]:
+    """Compute per-pulse beam jitter at the wire from BPM data.
 
     Uses BPM position data and transport matrices to reconstruct beam
-    position jitter at the wire location, then subtracts it from the
-    wire position data.
+    position jitter at the wire location via least-squares orbit fit.
 
     Parameters
     ----------
@@ -29,9 +27,9 @@ def correct_jitter(
 
     Returns
     -------
-    WireMeasurementCollectionResult
-        New collection result with corrected wire positions,
-        jitter_corrected=True, and jitter_rms_x/jitter_rms_y populated.
+    tuple[np.ndarray, np.ndarray]
+        (jitter_x, jitter_y) per-pulse beam position jitter at the wire
+        in um, one value per buffer pulse.
 
     Raises
     ------
@@ -39,8 +37,6 @@ def correct_jitter(
         If no BPM data is found in the collection result or if fewer than
         2 BPMs have valid data.
     """
-    wire_name = collection_result.metadata.wire_name
-    install_angle = collection_result.metadata.install_angle
     raw_data = collection_result.raw_data
 
     bpm_x_data, bpm_y_data, bpm_names = _extract_bpm_data(raw_data)
@@ -51,27 +47,13 @@ def correct_jitter(
             f"found {len(bpm_names)}."
         )
 
+    wire_name = collection_result.metadata.wire_name
+
     rmat_x, rmat_y = get_jitter_rmat(
         wire_name, bpm_names, beampath, physics_model, include_energy
     )
 
-    wire_positions = raw_data[wire_name].copy()
-
-    jitter_x, jitter_y = _compute_orbit_fit(bpm_x_data, bpm_y_data, rmat_x, rmat_y)
-
-    jitter_stage = xy_to_stage(jitter_x, jitter_y, install_angle)
-    corrected_positions = wire_positions - jitter_stage
-
-    corrected_raw_data = dict(raw_data)
-    corrected_raw_data[wire_name] = corrected_positions
-
-    return WireMeasurementCollectionResult(
-        raw_data=corrected_raw_data,
-        metadata=collection_result.metadata,
-        jitter_corrected=True,
-        jitter_rms_x=float(np.std(jitter_x)),
-        jitter_rms_y=float(np.std(jitter_y)),
-    )
+    return _compute_orbit_fit(bpm_x_data, bpm_y_data, rmat_x, rmat_y)
 
 
 def get_jitter_rmat(

--- a/slac_measurements/wires/jitter_correction.py
+++ b/slac_measurements/wires/jitter_correction.py
@@ -132,34 +132,33 @@ def get_jitter_rmat(
 
 
 def _extract_bpm_data(
-    raw_data: dict[str, np.ndarray],
+    raw_data: dict,
 ) -> tuple[np.ndarray, np.ndarray, list[str]]:
     """Extract BPM x/y position data from raw_data dictionary.
 
-    Identifies BPM data by keys starting with 'BPM' and ending in ':X' / ':Y'.
-    The MAD device name is used as the BPM identifier.
+    BPM entries are keyed by device name (starting with 'BPM') and contain
+    a dict with 'x' and 'y' buffer arrays.
 
     Returns
     -------
     tuple
         (bpm_x_array, bpm_y_array, bpm_names) where arrays are
-        [N_bpms x N_pulses] and bpm_names are MAD device names.
+        [N_bpms x N_pulses] and bpm_names are device names.
     """
-    bpm_x_keys = sorted(k for k in raw_data if k.startswith("BPM") and k.endswith(":X"))
+    bpm_keys = sorted(k for k in raw_data if k.startswith("BPM"))
 
     bpm_names = []
     x_arrays = []
     y_arrays = []
 
-    for x_key in bpm_x_keys:
-        name = x_key[:-2]  # Strip ':X'
-        y_key = f"{name}:Y"
+    for name in bpm_keys:
+        bpm_data = raw_data[name]
 
-        if y_key not in raw_data:
+        if not isinstance(bpm_data, dict):
             continue
 
-        x_arr = raw_data[x_key]
-        y_arr = raw_data[y_key]
+        x_arr = bpm_data.get("x")
+        y_arr = bpm_data.get("y")
 
         if x_arr is None or y_arr is None:
             continue

--- a/slac_measurements/wires/jitter_correction.py
+++ b/slac_measurements/wires/jitter_correction.py
@@ -1,0 +1,224 @@
+import numpy as np
+
+from slac_measurements.wires.collection_results import WireMeasurementCollectionResult
+from slac_measurements.wires.coordinates import xy_to_stage
+
+
+def correct_jitter(
+    collection_result: WireMeasurementCollectionResult,
+    beampath: str,
+    physics_model: str = "BLEM",
+    include_energy: bool = True,
+) -> WireMeasurementCollectionResult:
+    """Apply jitter correction to a wire scan collection result.
+
+    Uses BPM position data and transport matrices to reconstruct beam
+    position jitter at the wire location, then subtracts it from the
+    wire position data.
+
+    Parameters
+    ----------
+    collection_result : WireMeasurementCollectionResult
+        Raw collection result containing wire positions and BPM x/y buffer data.
+    beampath : str
+        Beam path identifier for the model (e.g., "SC_HXR", "SC_DIAG0").
+    physics_model : str
+        Model source for R-matrix retrieval. Default "BLEM".
+    include_energy : bool
+        Whether to include the dispersion (energy) term in the orbit fit.
+
+    Returns
+    -------
+    WireMeasurementCollectionResult
+        New collection result with corrected wire positions,
+        jitter_corrected=True, and jitter_rms_x/jitter_rms_y populated.
+
+    Raises
+    ------
+    ValueError
+        If no BPM data is found in the collection result or if fewer than
+        2 BPMs have valid data.
+    """
+    wire_name = collection_result.metadata.wire_name
+    install_angle = collection_result.metadata.install_angle
+    raw_data = collection_result.raw_data
+
+    bpm_x_data, bpm_y_data, bpm_names = _extract_bpm_data(raw_data)
+
+    if len(bpm_names) < 2:
+        raise ValueError(
+            f"Jitter correction requires at least 2 BPMs with valid data, "
+            f"found {len(bpm_names)}."
+        )
+
+    rmat_x, rmat_y = get_jitter_rmat(
+        wire_name, bpm_names, beampath, physics_model, include_energy
+    )
+
+    wire_positions = raw_data[wire_name].copy()
+
+    jitter_x, jitter_y = _compute_orbit_fit(bpm_x_data, bpm_y_data, rmat_x, rmat_y)
+
+    jitter_stage = xy_to_stage(jitter_x, jitter_y, install_angle)
+    corrected_positions = wire_positions - jitter_stage
+
+    corrected_raw_data = dict(raw_data)
+    corrected_raw_data[wire_name] = corrected_positions
+
+    return WireMeasurementCollectionResult(
+        raw_data=corrected_raw_data,
+        metadata=collection_result.metadata,
+        jitter_corrected=True,
+        jitter_rms_x=float(np.std(jitter_x)),
+        jitter_rms_y=float(np.std(jitter_y)),
+    )
+
+
+def get_jitter_rmat(
+    wire_name: str,
+    bpm_names: list[str],
+    beampath: str,
+    physics_model: str = "BLEM",
+    include_energy: bool = True,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Get R-matrices from wire to each BPM for orbit fitting.
+
+    Parameters
+    ----------
+    wire_name : str
+        Wire device name (MAD element name).
+    bpm_names : list[str]
+        BPM control names (e.g., ["BPMS:HTR:120", "BPMS:HTR:320"]).
+    beampath : str
+        Beam path identifier for the model.
+    physics_model : str
+        Model source. Default "BLEM".
+    include_energy : bool
+        If True, include R16/R36 dispersion term (3-column matrix).
+        If False, use only R11,R12 / R33,R34 (2-column matrix).
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray]
+        (rmat_x, rmat_y) where:
+        - rmat_x is [N_bpms x 2] (or [N_bpms x 3] with energy)
+        - rmat_y is [N_bpms x 2] (or [N_bpms x 3] with energy)
+        Each row relates BPM position reading to beam state at wire.
+    """
+    from meme.model import Model
+
+    model = Model(beampath, model_source=physics_model, use_design=False)
+
+    n_cols = 3 if include_energy else 2
+    rmat_x = np.zeros((len(bpm_names), n_cols))
+    rmat_y = np.zeros((len(bpm_names), n_cols))
+
+    for i, bpm_name in enumerate(bpm_names):
+        rmat_6x6 = model.get_rmat(from_device=wire_name, to_device=bpm_name)
+
+        # x plane: position at BPM from (x, x') at wire
+        rmat_x[i, 0] = rmat_6x6[0, 0]  # R11
+        rmat_x[i, 1] = rmat_6x6[0, 1]  # R12
+        if include_energy:
+            rmat_x[i, 2] = rmat_6x6[0, 5]  # R16
+
+        # y plane: position at BPM from (y, y') at wire
+        rmat_y[i, 0] = rmat_6x6[2, 2]  # R33
+        rmat_y[i, 1] = rmat_6x6[2, 3]  # R34
+        if include_energy:
+            rmat_y[i, 2] = rmat_6x6[2, 5]  # R36
+
+    return rmat_x, rmat_y
+
+
+def _extract_bpm_data(
+    raw_data: dict[str, np.ndarray],
+) -> tuple[np.ndarray, np.ndarray, list[str]]:
+    """Extract BPM x/y position data from raw_data dictionary.
+
+    Identifies BPM data by keys starting with 'BPM' and ending in ':X' / ':Y'.
+    The MAD device name is used as the BPM identifier.
+
+    Returns
+    -------
+    tuple
+        (bpm_x_array, bpm_y_array, bpm_names) where arrays are
+        [N_bpms x N_pulses] and bpm_names are MAD device names.
+    """
+    bpm_x_keys = sorted(k for k in raw_data if k.startswith("BPM") and k.endswith(":X"))
+
+    bpm_names = []
+    x_arrays = []
+    y_arrays = []
+
+    for x_key in bpm_x_keys:
+        name = x_key[:-2]  # Strip ':X'
+        y_key = f"{name}:Y"
+
+        if y_key not in raw_data:
+            continue
+
+        x_arr = raw_data[x_key]
+        y_arr = raw_data[y_key]
+
+        if x_arr is None or y_arr is None:
+            continue
+        if np.all(np.isnan(x_arr)) or np.all(np.isnan(y_arr)):
+            continue
+
+        bpm_names.append(name)
+        x_arrays.append(x_arr)
+        y_arrays.append(y_arr)
+
+    if not bpm_names:
+        raise ValueError("No valid BPM position data found in collection result.")
+
+    bpm_x_data = np.array(x_arrays)  # [N_bpms x N_pulses]
+    bpm_y_data = np.array(y_arrays)  # [N_bpms x N_pulses]
+
+    return bpm_x_data, bpm_y_data, bpm_names
+
+
+def _compute_orbit_fit(
+    bpm_x_data: np.ndarray,
+    bpm_y_data: np.ndarray,
+    rmat_x: np.ndarray,
+    rmat_y: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Compute beam position at wire from BPM readings via least-squares orbit fit.
+
+    Parameters
+    ----------
+    bpm_x_data : np.ndarray
+        BPM x positions [N_bpms x N_pulses] in mm.
+    bpm_y_data : np.ndarray
+        BPM y positions [N_bpms x N_pulses] in mm.
+    rmat_x : np.ndarray
+        X-plane transport matrix [N_bpms x 2 or 3].
+    rmat_y : np.ndarray
+        Y-plane transport matrix [N_bpms x 2 or 3].
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray]
+        (jitter_x, jitter_y) - reconstructed beam position jitter at wire
+        for each pulse, in um (matching wire position units).
+    """
+    # Compute deviations from mean (mm)
+    delta_x = bpm_x_data - bpm_x_data.mean(axis=1, keepdims=True)
+    delta_y = bpm_y_data - bpm_y_data.mean(axis=1, keepdims=True)
+
+    # Convert mm -> m for orbit fit
+    delta_x_m = delta_x * 1e-3
+    delta_y_m = delta_y * 1e-3
+
+    # Least-squares fit: rmat @ orbit = delta_bpm for each pulse
+    # orbit_x shape: [n_params x N_pulses], orbit_x[0] is x position at wire
+    orbit_x, _, _, _ = np.linalg.lstsq(rmat_x, delta_x_m, rcond=None)
+    orbit_y, _, _, _ = np.linalg.lstsq(rmat_y, delta_y_m, rcond=None)
+
+    # Position at wire (first element of orbit vector), convert m -> um
+    jitter_x_um = orbit_x[0, :] * 1e6
+    jitter_y_um = orbit_y[0, :] * 1e6
+
+    return jitter_x_um, jitter_y_um

--- a/slac_measurements/wires/jitter_correction.py
+++ b/slac_measurements/wires/jitter_correction.py
@@ -3,16 +3,20 @@ import numpy as np
 from slac_measurements.wires.collection_results import WireMeasurementCollectionResult
 
 
+_DISPERSION_THRESHOLD = 1e-4
+
+
 def compute_jitter(
     collection_result: WireMeasurementCollectionResult,
     beampath: str,
     physics_model: str = "BLEM",
-    include_energy: bool = True,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Compute per-pulse beam jitter at the wire from BPM data.
 
     Uses BPM position data and transport matrices to reconstruct beam
     position jitter at the wire location via least-squares orbit fit.
+    The dispersion (energy) term is automatically included when the
+    R16/R36 elements are non-negligible.
 
     Parameters
     ----------
@@ -22,8 +26,6 @@ def compute_jitter(
         Beam path identifier for the model (e.g., "SC_HXR", "SC_DIAG0").
     physics_model : str
         Model source for R-matrix retrieval. Default "BLEM".
-    include_energy : bool
-        Whether to include the dispersion (energy) term in the orbit fit.
 
     Returns
     -------
@@ -49,9 +51,7 @@ def compute_jitter(
 
     wire_name = collection_result.metadata.wire_name
 
-    rmat_x, rmat_y = get_jitter_rmat(
-        wire_name, bpm_names, beampath, physics_model, include_energy
-    )
+    rmat_x, rmat_y = get_jitter_rmat(wire_name, bpm_names, beampath, physics_model)
 
     return _compute_orbit_fit(bpm_x_data, bpm_y_data, rmat_x, rmat_y)
 
@@ -61,9 +61,11 @@ def get_jitter_rmat(
     bpm_names: list[str],
     beampath: str,
     physics_model: str = "BLEM",
-    include_energy: bool = True,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Get R-matrices from wire to each BPM for orbit fitting.
+
+    Always fetches R16/R36 (dispersion) columns. The orbit fit will
+    automatically drop them if they are below threshold.
 
     Parameters
     ----------
@@ -75,40 +77,30 @@ def get_jitter_rmat(
         Beam path identifier for the model.
     physics_model : str
         Model source. Default "BLEM".
-    include_energy : bool
-        If True, include R16/R36 dispersion term (3-column matrix).
-        If False, use only R11,R12 / R33,R34 (2-column matrix).
 
     Returns
     -------
     tuple[np.ndarray, np.ndarray]
-        (rmat_x, rmat_y) where:
-        - rmat_x is [N_bpms x 2] (or [N_bpms x 3] with energy)
-        - rmat_y is [N_bpms x 2] (or [N_bpms x 3] with energy)
-        Each row relates BPM position reading to beam state at wire.
+        (rmat_x, rmat_y) where each is [N_bpms x 3] containing
+        [R11, R12, R16] and [R33, R34, R36] respectively.
     """
     from meme.model import Model
 
     model = Model(beampath, model_source=physics_model, use_design=False)
 
-    n_cols = 3 if include_energy else 2
-    rmat_x = np.zeros((len(bpm_names), n_cols))
-    rmat_y = np.zeros((len(bpm_names), n_cols))
+    rmat_x = np.zeros((len(bpm_names), 3))
+    rmat_y = np.zeros((len(bpm_names), 3))
 
     for i, bpm_name in enumerate(bpm_names):
         rmat_6x6 = model.get_rmat(from_device=wire_name, to_device=bpm_name)
 
-        # x plane: position at BPM from (x, x') at wire
         rmat_x[i, 0] = rmat_6x6[0, 0]  # R11
         rmat_x[i, 1] = rmat_6x6[0, 1]  # R12
-        if include_energy:
-            rmat_x[i, 2] = rmat_6x6[0, 5]  # R16
+        rmat_x[i, 2] = rmat_6x6[0, 5]  # R16
 
-        # y plane: position at BPM from (y, y') at wire
         rmat_y[i, 0] = rmat_6x6[2, 2]  # R33
         rmat_y[i, 1] = rmat_6x6[2, 3]  # R34
-        if include_energy:
-            rmat_y[i, 2] = rmat_6x6[2, 5]  # R36
+        rmat_y[i, 2] = rmat_6x6[2, 5]  # R36
 
     return rmat_x, rmat_y
 
@@ -168,6 +160,10 @@ def _compute_orbit_fit(
 ) -> tuple[np.ndarray, np.ndarray]:
     """Compute beam position at wire from BPM readings via least-squares orbit fit.
 
+    The dispersion column (R16/R36) is automatically excluded from the
+    fit if its maximum absolute value is below _DISPERSION_THRESHOLD,
+    matching the legacy MATLAB behavior in beamAnalysis_orbitFit.
+
     Parameters
     ----------
     bpm_x_data : np.ndarray
@@ -175,9 +171,9 @@ def _compute_orbit_fit(
     bpm_y_data : np.ndarray
         BPM y positions [N_bpms x N_pulses] in mm.
     rmat_x : np.ndarray
-        X-plane transport matrix [N_bpms x 2 or 3].
+        X-plane transport matrix [N_bpms x 3] (R11, R12, R16).
     rmat_y : np.ndarray
-        Y-plane transport matrix [N_bpms x 2 or 3].
+        Y-plane transport matrix [N_bpms x 3] (R33, R34, R36).
 
     Returns
     -------
@@ -185,6 +181,12 @@ def _compute_orbit_fit(
         (jitter_x, jitter_y) - reconstructed beam position jitter at wire
         for each pulse, in um (matching wire position units).
     """
+    # Drop dispersion column if negligible
+    if np.max(np.abs(rmat_x[:, 2])) < _DISPERSION_THRESHOLD:
+        rmat_x = rmat_x[:, :2]
+    if np.max(np.abs(rmat_y[:, 2])) < _DISPERSION_THRESHOLD:
+        rmat_y = rmat_y[:, :2]
+
     # Compute deviations from mean (mm)
     delta_x = bpm_x_data - bpm_x_data.mean(axis=1, keepdims=True)
     delta_y = bpm_y_data - bpm_y_data.mean(axis=1, keepdims=True)

--- a/slac_measurements/wires/scan.py
+++ b/slac_measurements/wires/scan.py
@@ -24,6 +24,7 @@ class WireBeamProfileMeasurement(slac_measurements.beam_profile.BeamProfileMeasu
         scan_mode: ScanMode = "otf",
         fitting_method: FittingMethod = "gaussian",
         rms_detector: Optional[str] = None,
+        jitter_correction: bool = False,
     ) -> WireMeasurementAnalysisResult:
         """
         Run a wire scan and return the analyzed result.
@@ -33,6 +34,8 @@ class WireBeamProfileMeasurement(slac_measurements.beam_profile.BeamProfileMeasu
         scan_mode : "otf" (default) or "step".
         fitting_method : "gaussian" (default), "asymmetric_gaussian", or "super_gaussian".
         rms_detector : Detector for RMS sizes; defaults to the collection metadata default.
+        jitter_correction : If True, apply orbit-fit jitter correction before analysis.
+            Requires jitter_correction_bpms defined in wire metadata.
         """
 
         collection = create_wire_collection(
@@ -41,6 +44,14 @@ class WireBeamProfileMeasurement(slac_measurements.beam_profile.BeamProfileMeasu
             beampath=self.beampath,
         )
         self.collection_result = collection.measure()
+
+        if jitter_correction:
+            from slac_measurements.wires.jitter_correction import correct_jitter
+
+            self.collection_result = correct_jitter(
+                self.collection_result, beampath=self.beampath
+            )
+
         analysis = WireMeasurementAnalysis(
             collection_result=self.collection_result,
             fitting_method=fitting_method,

--- a/slac_measurements/wires/scan.py
+++ b/slac_measurements/wires/scan.py
@@ -34,7 +34,7 @@ class WireBeamProfileMeasurement(slac_measurements.beam_profile.BeamProfileMeasu
         scan_mode : "otf" (default) or "step".
         fitting_method : "gaussian" (default), "asymmetric_gaussian", or "super_gaussian".
         rms_detector : Detector for RMS sizes; defaults to the collection metadata default.
-        jitter_correction : If True, apply orbit-fit jitter correction before analysis.
+        jitter_correction : If True, apply orbit-fit jitter correction during analysis.
             Requires jitter_correction_bpms defined in wire metadata.
         """
 
@@ -45,15 +45,12 @@ class WireBeamProfileMeasurement(slac_measurements.beam_profile.BeamProfileMeasu
         )
         self.collection_result = collection.measure()
 
-        if jitter_correction:
-            from slac_measurements.wires.jitter_correction import correct_jitter
-
-            self.collection_result = correct_jitter(
-                self.collection_result, beampath=self.beampath
-            )
-
         analysis = WireMeasurementAnalysis(
             collection_result=self.collection_result,
             fitting_method=fitting_method,
         )
-        return analysis.analyze(rms_detector=rms_detector)
+        return analysis.analyze(
+            rms_detector=rms_detector,
+            jitter_correction=jitter_correction,
+            beampath=self.beampath,
+        )

--- a/slac_measurements/wires/scan.py
+++ b/slac_measurements/wires/scan.py
@@ -52,5 +52,4 @@ class WireBeamProfileMeasurement(slac_measurements.beam_profile.BeamProfileMeasu
         return analysis.analyze(
             rms_detector=rms_detector,
             jitter_correction=jitter_correction,
-            beampath=self.beampath,
         )

--- a/tests/test_wire_scan.py
+++ b/tests/test_wire_scan.py
@@ -158,6 +158,7 @@ class WireBeamProfileMeasurementTest(TestCase):
         )
         mock_analysis_cls.return_value.analyze.assert_called_once_with(
             rms_detector="D2",
+            jitter_correction=False,
         )
 
     def test_collection_result_round_trip_preserves_buffer_number(self):

--- a/tests/test_wire_scan_analysis.py
+++ b/tests/test_wire_scan_analysis.py
@@ -479,32 +479,6 @@ class TestWireMeasurementAnalysisResult(TestCase):
         # Use a deep copy of one shared template so tests remain isolated.
         self.result = self._result_template.model_copy(deep=True)
 
-    def test_set_rms_detector_updates_rms_sizes_and_metadata(self):
-        self.result.set_rms_detector("D2")
-
-        np.testing.assert_array_equal(
-            np.asarray(self.result.rms_sizes),
-            np.array([3.5, 4.5], dtype=object),
-        )
-        self.assertEqual(self.result.metadata.rms_detector, "D2")
-        self.assertEqual(self.result.collection_result.metadata.rms_detector, "D2")
-
-    def test_set_rms_detector_uses_default_when_detector_omitted(self):
-        self.result.metadata.rms_detector = "D2"
-        self.result.collection_result.metadata.rms_detector = "D2"
-
-        self.result.set_rms_detector()
-
-        np.testing.assert_array_equal(
-            np.asarray(self.result.rms_sizes),
-            np.array([1.25, 2.5], dtype=object),
-        )
-        self.assertEqual(self.result.metadata.rms_detector, "D1")
-
-    def test_set_rms_detector_raises_for_unknown_detector(self):
-        with self.assertRaises(ValueError):
-            self.result.set_rms_detector("D3")
-
     def test_save_to_h5_handles_object_rms_sizes(self):
         self.result.rms_sizes = np.array([1.25, None], dtype=object)
 


### PR DESCRIPTION
Jitter correction reconstructs the beam's pulse-to-pulse position jitter at the wire location and subtracts it from the measured wire positions before fitting. This removes orbit noise from the beam profile measurement, yielding a cleaner size estimate.

**The Math**

For each pulse in a wire scan, we have simultaneous BPM readings from multiple BPMs along the beamline. The algorithm:

1. Centroid subtraction — For each BPM, subtract the mean position across all pulses to get pulse-to-pulse deviations (Δx, Δy).
2. Orbit reconstruction via least-squares — Using the R-matrices (from `meme`) that relate the wire location to each BPM, solve the inverse transport problem: given the observed BPM deviations, reconstruct the beam position and angle at the wire. This is a least-squares fit (`np.linalg.lstsq`) of R @ [position, angle, (energy)]ᵀ = Δ_bpm using all available BPMs simultaneously. The dispersion column (R16/R36) is automatically excluded when its maximum absolute value is below threshold, matching the legacy MATLAB `beamAnalysis_orbitFit` behavior.
3. Subtraction in beam coordinates — The reconstructed jitter is subtracted per-pulse in beam space after stage-to-beam conversion: x-profile subtracts `jitter_x`, y-profile subtracts `jitter_y`, and u-profile subtracts the angular projection `jitter_x * sin(θ) + jitter_y * cos(θ)`.
4. At least 2 BPMs with valid data are required for the fit.

**Code Changes**

_Coordinate transformations pulled into a reusable module (`wires/coordinates.py`)_
- Provides `stage_to_beam`, `beam_to_stage`, `xy_to_stage`, and `wire_angle_scales`
- Used by both analysis and jitter correction — no duplicated trig

_Data collection now instantiates jitter BPMs (`wires/collection.py`)_
- If `jitter_bpms` is defined in the wire's metadata, collection automatically instantiates each BPM device
- Each BPM's X and Y buffer data is gathered using a "`bpm_buffer`" collection method key, which the data collection loop translates into calls to `device.x_buffer()` and `device.y_buffer()`

_Jitter correction module (`wires/jitter_correction.py`)_
- `compute_jitter(collection_result, beampath, physics_model)` — top-level entry point, returns `(jitter_x, jitter_y)` per-pulse arrays in μm
- `get_jitter_rmat(wire_name, bpm_names, beampath, physics_model)` — fetches R-matrices from the meme model (R11/R12/R16 for x, R33/R34/R36 for y)
- Dispersion columns are dropped automatically when below `_DISPERSION_THRESHOLD`
- BPM data is extracted from `raw_data` by key prefix ("BPM")

_New attributes on the analysis result (`wires/analysis_results.py`)_

- `jitter_corrected: bool` — whether jitter correction was applied
- `jitter_rms: tuple[float, float] | None` — `(rms_x, rms_y)` of the reconstructed jitter in μm
- `fitting_method: str` — the fitting method used for this result

_`reanalyze()` method replaces `set_rms_detector()` (`wires/analysis_results.py`)_
- `result.reanalyze(jitter_correction=True)` re-runs the full analysis on the same collected data with new settings
- Returns a new `WireMeasurementAnalysisResult` — the original is unchanged

_Jitter correction lives inside the analysis step (`wires/analysis.py`)_

- The pipeline is: collect → analyze (with jitter correction computed and applied internally before fitting)
- When  `jitter_correction=True`, `analyze()` calls `compute_jitter` and stores the result in private attributes (`_jitter_x, _jitter_y`)
- Per-profile subtraction happens in `_apply_jitter_correction()` after stage-to-beam conversion

_User-facing API (`wires/scan.py`)_=
- Pass `jitter_correction=True` to `WireBeamProfileMeasurement.measure()` to enable it
- Requires that `jitter_bpms` is populated in the wire metadata for the device being scanned