### PR TITLE
Implement disconnect methods for TMITLoss and BaseWireMeasurementCollection

### DIFF
--- a/slac_measurements/tmit_loss.py
+++ b/slac_measurements/tmit_loss.py
@@ -47,6 +47,14 @@ class TMITLoss(Measurement):
         data = self._get_bpm_data()
         return self._calc_tmit_loss(data, self.idx_upstream, self.idx_downstream)
 
+    def disconnect(self):
+        """Disconnect all BPM PV connections held by this measurement."""
+        if self.bpms is None:
+            return
+        for bpm in self.bpms.values():
+            if hasattr(bpm, "controls_information"):
+                bpm.controls_information.PVs.disconnect()
+
     def _get_bpm_data(self) -> np.ndarray:
         """Collect TMIT buffer data from all BPMs. Returns shape (n_bpms, n_samples)."""
         n_samples = self.buffer.n_measurements

--- a/slac_measurements/wires/collection.py
+++ b/slac_measurements/wires/collection.py
@@ -99,6 +99,7 @@ class BaseWireMeasurementCollection(
             self.metadata.timestamp = datetime.now()
         finally:
             _release_buffer_safely()
+            self._disconnect_devices()
 
         return WireMeasurementCollectionResult(
             raw_data=self.data,
@@ -279,6 +280,18 @@ class BaseWireMeasurementCollection(
             min_expected_s * _ACQUISITION_TIMEOUT_MARGIN,
             min_expected_s + _ACQUISITION_TIMEOUT_MIN_EXTRA_S,
         )
+
+    def _disconnect_devices(self) -> None:
+        """Disconnect PV connections from per-scan devices (detectors, BPMs)."""
+        if self.devices is None:
+            return
+        for name, device in self.devices.items():
+            if name == self.beam_profile_device.name:
+                continue
+            if hasattr(device, "disconnect"):
+                device.disconnect()
+            elif hasattr(device, "controls_information"):
+                device.controls_information.PVs.disconnect()
 
     @abstractmethod
     def _run_collection_scan(self) -> None:


### PR DESCRIPTION
This pull request adds explicit disconnection logic for (PV) connections in measurement devices to ensure resources are properly released after data collection. The changes help prevent resource leaks and improve the robustness of the measurement system.
