### PR TITLE
[BUGFIX] BPM Data wasn't being saved properly

### DIFF
--- a/slac_measurements/wires/collection_results.py
+++ b/slac_measurements/wires/collection_results.py
@@ -115,12 +115,14 @@ class WireMeasurementCollectionResult(BeamProfileCollectionResult):
         for device_name, data in self.raw_data.items():
             if isinstance(data, np.ndarray):
                 group.create_dataset(device_name, data=data)
+            elif isinstance(data, dict):
+                sub_group = group.create_group(device_name)
+                for key, value in data.items():
+                    sub_group.create_dataset(key, data=np.asarray(value))
             else:
-                # Try to convert to numpy array
                 try:
                     group.create_dataset(device_name, data=np.array(data))
                 except (TypeError, ValueError):
-                    # Store as string representation if conversion fails
                     group.attrs[f"{device_name}_unsupported"] = str(data)
 
 
@@ -207,6 +209,10 @@ def _load_raw_data(group: h5py.Group) -> dict[str, Any]:
     raw_data = {}
 
     for device_name in group.keys():
-        raw_data[device_name] = group[device_name][:]
+        item = group[device_name]
+        if isinstance(item, h5py.Group):
+            raw_data[device_name] = {k: item[k][:] for k in item.keys()}
+        else:
+            raw_data[device_name] = item[:]
 
     return raw_data


### PR DESCRIPTION
With the addition of Jitter Correction to wire scan measurements, the save and load methods were not updated on results objects.  BPMs are saved as a dictionary of `{<device_name>: {"x": [data], "y": [data]}}`.  The save method in its current state cannot handle nested dictionaries. This bug fix allows users to save and load nested dictionaries of BPM data.