### PR TITLE
Add warnings for all-NaN signals and profiles in analysis

### DIFF
--- a/slac_measurements/wires/analysis/analysis.py
+++ b/slac_measurements/wires/analysis/analysis.py
@@ -250,8 +250,18 @@ class WireMeasurementAnalysis(slac_measurements.beam_profile.BeamProfileAnalysis
             if detector_name not in profile_data.detectors:
                 continue
 
+            signal = profile_data.detectors[detector_name].values
+            if np.all(np.isnan(signal)):
+                warnings.warn(
+                    f"Detector '{detector_name}' returned all NaN for "
+                    f"profile '{profile}' — skipping.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                continue
+
             detector_fits[detector_name] = _fit_detector_in_profile(
-                x_beam, profile_data.detectors[detector_name].values, profile
+                x_beam, signal, profile
             )
 
         return FitResult(detectors=detector_fits)

--- a/tests/test_wire_scan_analysis.py
+++ b/tests/test_wire_scan_analysis.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 from datetime import datetime
 from tempfile import TemporaryDirectory
@@ -382,6 +384,36 @@ class TestWireMeasurementAnalysisOtherMethods(TestCase):
 
         with self.assertRaises(ValueError):
             analysis._get_rms_sizes({}, detector="D3")
+
+    def test_fit_profile_skips_all_nan_detector_with_warning(self):
+        analysis = self._make_analysis(
+            raw_data={"WIRE": np.array([0.0, 1.0, 2.0])},
+            detectors=["D1"],
+            active_profiles=["x"],
+            scan_ranges={"x": (0, 2)},
+        )
+        profile_measurements = {
+            "x": ProfileMeasurement(
+                positions=np.array([0.0, 1.0, 2.0]),
+                profile_indices=np.array([0, 1, 2]),
+                detectors={
+                    "D1": DetectorProfileMeasurement(
+                        values=np.array([np.nan, np.nan, np.nan]),
+                        units="counts",
+                        label="D1",
+                    )
+                },
+            )
+        }
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = analysis._fit_profile(profile_measurements, "x", ["D1"])
+
+        self.assertEqual(result.detectors, {})
+        self.assertEqual(len(w), 1)
+        self.assertIn("all NaN", str(w[0].message))
+        self.assertIn("D1", str(w[0].message))
 
     def test_analyze_orchestrates_helper_methods_and_returns_result(self):
         analysis = self._make_analysis()


### PR DESCRIPTION
This pull request improves the handling of detector data containing only NaN values and adds a corresponding unit test to ensure this behavior. The main changes are:

**Error Handling Improvements:**

* Updated the `_peak_window` function in `analysis.py` to skip detectors that return all-NaN signals and emit a warning, preventing attempts to fit invalid data.

**Testing Enhancements:**

* Added the `test_fit_profile_skips_all_nan_detector_with_warning` test in `test_wire_scan_analysis.py` to verify that detectors with all-NaN values are skipped and that an appropriate warning is issued.
* Imported the `warnings` module in the test file to support the new test case.