### PR TITLE
Introduce wire scan MATLAB export functionality and improve data handling

### DIFF
--- a/slac_measurements/wires/analysis/mat_export.py
+++ b/slac_measurements/wires/analysis/mat_export.py
@@ -1,0 +1,410 @@
+"""Export WireMeasurementAnalysisResult to MATLAB .mat format.
+
+Produces files compatible with the MATLAB wirescan_gui (File > Open).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import scipy.io
+
+if TYPE_CHECKING:
+    from slac_measurements.wires.analysis.results import (
+        WireMeasurementAnalysisResult,
+    )
+
+
+def datetime_to_matlab_datenum(dt: datetime) -> float:
+    """Convert a Python datetime to a MATLAB datenum (days since Jan 0, 0000)."""
+    MATLAB_EPOCH_OFFSET = 719529.0  # datenum('1970-01-01')
+    epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return MATLAB_EPOCH_OFFSET + (dt - epoch).total_seconds() / 86400.0
+
+
+def analysis_result_to_mat(
+    result: WireMeasurementAnalysisResult,
+    filepath: str,
+    *,
+    include_rmat: bool = False,
+    physics_model: str = "BLEM",
+) -> str:
+    """Export a WireMeasurementAnalysisResult as a MATLAB .mat file.
+
+    The output file contains a single ``data`` struct variable matching
+    the layout produced by the MATLAB ``wirescan_gui`` ``dataSave``
+    function, so it can be loaded directly with ``File > Open``.
+
+    Parameters
+    ----------
+    result : WireMeasurementAnalysisResult
+        The analysis result to export.
+    filepath : str
+        Output ``.mat`` file path.
+    include_rmat : bool
+        Whether to fetch R-matrices from the optics model.  Requires
+        network access.  Default False.
+    physics_model : str
+        Model source for R-matrix retrieval.  Default ``"BLEM"``.
+
+    Returns
+    -------
+    str
+        Path to the saved ``.mat`` file.
+    """
+    from slac_measurements.wires.analysis.coordinates import stage_to_beam
+
+    metadata = result.collection_result.metadata
+    raw_data = result.collection_result.raw_data
+
+    data: dict[str, Any] = {}
+
+    # --- Scalar / string fields ---
+    data["name"] = metadata.wire_name
+    data["wireName"] = metadata.wire_name
+    data["wireMode"] = "wire"
+    data["beampath"] = metadata.beampath or ""
+    data["status"] = np.bool_(True)
+
+    if metadata.timestamp is not None:
+        data["ts"] = datetime_to_matlab_datenum(metadata.timestamp)
+    else:
+        data["ts"] = np.float64(0.0)
+
+    # --- Wire geometry ---
+    data["wireAngle"] = np.float64(metadata.install_angle)
+    data["wireScanDir"] = np.float64(0.0)
+
+    wire_dir = {}
+    wire_limit = {}
+    wire_center = {}
+    wire_size = {}
+    for tag in ("x", "y", "u"):
+        wire_dir[tag] = np.bool_(tag in metadata.active_profiles)
+        if tag in metadata.scan_ranges:
+            lo, hi = metadata.scan_ranges[tag]
+            wire_limit[tag] = np.array([lo, hi], dtype=np.float64)
+        else:
+            wire_limit[tag] = np.array([0.0, 0.0], dtype=np.float64)
+        wire_center[tag] = np.float64(0.0)
+        wire_size[tag] = np.float64(12.5)
+
+    data["wireDir"] = wire_dir
+    data["wireLimit"] = wire_limit
+    data["wireCenter"] = wire_center
+    data["wireSize"] = wire_size
+
+    # --- Device lists and raw data ---
+    pmt_keys, bpm_keys, toro_keys = _classify_raw_data_keys(raw_data, metadata)
+
+    data["PMTList"] = (
+        np.array(pmt_keys, dtype=object) if pmt_keys else np.array([], dtype=object)
+    )
+    data["BPMList"] = (
+        np.array(bpm_keys, dtype=object) if bpm_keys else np.array([], dtype=object)
+    )
+    data["toroList"] = (
+        np.array(toro_keys, dtype=object) if toro_keys else np.array([], dtype=object)
+    )
+
+    wire_key = metadata.wire_name
+    if wire_key in raw_data:
+        wire_arr = np.asarray(raw_data[wire_key], dtype=np.float64)
+        data["wireData"] = wire_arr.reshape(1, -1, 1)
+        data["wireMask"] = np.ones_like(data["wireData"], dtype=np.float64)
+    else:
+        data["wireData"] = np.zeros((1, 0, 1), dtype=np.float64)
+        data["wireMask"] = np.zeros((1, 0, 1), dtype=np.float64)
+
+    n_pulses = data["wireData"].shape[1]
+
+    if pmt_keys:
+        pmt_arrays = []
+        for key in pmt_keys:
+            arr = np.asarray(raw_data.get(key, np.zeros(n_pulses)), dtype=np.float64)
+            pmt_arrays.append(arr.ravel())
+        data["PMTData"] = np.array(pmt_arrays).reshape(len(pmt_keys), n_pulses, 1)
+    else:
+        data["PMTData"] = np.zeros((0, n_pulses, 1), dtype=np.float64)
+
+    if bpm_keys:
+        bpmx_arrays = []
+        bpmy_arrays = []
+        for key in bpm_keys:
+            bpm_val = raw_data.get(key, {})
+            if isinstance(bpm_val, dict):
+                bpmx_arrays.append(
+                    np.asarray(
+                        bpm_val.get("x", np.zeros(n_pulses)), dtype=np.float64
+                    ).ravel()
+                )
+                bpmy_arrays.append(
+                    np.asarray(
+                        bpm_val.get("y", np.zeros(n_pulses)), dtype=np.float64
+                    ).ravel()
+                )
+            else:
+                bpmx_arrays.append(np.zeros(n_pulses, dtype=np.float64))
+                bpmy_arrays.append(np.zeros(n_pulses, dtype=np.float64))
+        data["BPMXData"] = np.array(bpmx_arrays).reshape(len(bpm_keys), n_pulses, 1)
+        data["BPMYData"] = np.array(bpmy_arrays).reshape(len(bpm_keys), n_pulses, 1)
+    else:
+        data["BPMXData"] = np.zeros((0, n_pulses, 1), dtype=np.float64)
+        data["BPMYData"] = np.zeros((0, n_pulses, 1), dtype=np.float64)
+
+    if toro_keys:
+        toro_arrays = []
+        for key in toro_keys:
+            toro_arrays.append(
+                np.asarray(
+                    raw_data.get(key, np.zeros(n_pulses)), dtype=np.float64
+                ).ravel()
+            )
+        data["toroData"] = np.array(toro_arrays).reshape(len(toro_keys), n_pulses, 1)
+    else:
+        data["toroData"] = np.zeros((0, n_pulses, 1), dtype=np.float64)
+
+    # --- R-matrices (optional) ---
+    if include_rmat and bpm_keys:
+        try:
+            data["rMatList"] = _fetch_rmat(
+                metadata.wire_name, bpm_keys, metadata.beampath, physics_model
+            )
+        except Exception:
+            data["rMatList"] = np.zeros((4, 6, len(bpm_keys)), dtype=np.float64)
+    else:
+        n_bpm = len(bpm_keys)
+        data["rMatList"] = (
+            np.zeros((4, 6, n_bpm), dtype=np.float64)
+            if n_bpm
+            else np.zeros((4, 6, 0), dtype=np.float64)
+        )
+
+    # --- Calibrated profiles (pos / signal) ---
+    default_det = metadata.default_detector
+    pos = {}
+    signal = {}
+    for tag in ("x", "y", "u"):
+        if tag in result.profiles and default_det:
+            prof = result.profiles[tag]
+            positions_beam = stage_to_beam(prof.positions, tag, metadata.install_angle)
+            pos[tag] = positions_beam.astype(np.float64)
+            det_data = prof.detectors.get(default_det)
+            signal[tag] = (
+                det_data.values.astype(np.float64)
+                if det_data is not None
+                else np.zeros_like(positions_beam)
+            )
+        else:
+            pos[tag] = np.zeros(0, dtype=np.float64)
+            signal[tag] = np.zeros(0, dtype=np.float64)
+
+    data["pos"] = pos
+    data["signal"] = signal
+
+    if default_det and metadata.detectors:
+        try:
+            data["selectPMT"] = np.float64(metadata.detectors.index(default_det) + 1)
+        except ValueError:
+            data["selectPMT"] = np.float64(1.0)
+    else:
+        data["selectPMT"] = np.float64(1.0)
+
+    # --- Beam struct (fit results) ---
+    data["beam"] = _build_beam_struct(result, pos, signal)
+
+    # --- beamPV ---
+    data["beamPV"] = _build_beam_pv(metadata.wire_name, data["beam"])
+
+    scipy.io.savemat(filepath, {"data": data}, do_compression=True, oned_as="row")
+    return filepath
+
+
+def _classify_raw_data_keys(
+    raw_data: dict[str, Any], metadata: Any
+) -> tuple[list[str], list[str], list[str]]:
+    """Separate raw_data keys into PMT, BPM, and toroid lists."""
+    wire_name = metadata.wire_name
+    detector_set = set(metadata.detectors) if metadata.detectors else set()
+
+    pmt_keys: list[str] = []
+    bpm_keys: list[str] = []
+    toro_keys: list[str] = []
+
+    for key in sorted(raw_data.keys()):
+        if key == wire_name:
+            continue
+        if key in detector_set:
+            pmt_keys.append(key)
+        elif "BPM" in key.upper():
+            bpm_keys.append(key)
+        elif "TORO" in key.upper():
+            toro_keys.append(key)
+        elif isinstance(raw_data[key], dict) and "x" in raw_data[key]:
+            bpm_keys.append(key)
+
+    # Ensure pmt_keys matches detector order from metadata
+    if metadata.detectors:
+        ordered_pmt = [d for d in metadata.detectors if d in set(pmt_keys)]
+        pmt_keys = ordered_pmt
+
+    return pmt_keys, bpm_keys, toro_keys
+
+
+def _build_beam_struct(
+    result: WireMeasurementAnalysisResult,
+    pos: dict[str, np.ndarray],
+    signal: dict[str, np.ndarray],
+) -> np.ndarray:
+    """Build MATLAB-compatible beam struct array.
+
+    Returns a numpy object array of shape (1, 1) containing a dict,
+    which scipy.io.savemat renders as a 1x1 struct array.
+    """
+    from slac_measurements.wires.analysis.coordinates import stage_to_beam
+
+    metadata = result.collection_result.metadata
+    default_det = metadata.default_detector
+    fit_result = result.fit_result
+
+    method_name = result.fitting_method.capitalize()
+    if method_name == "Gaussian":
+        method_name = "Gaussian"
+
+    stats = np.zeros(6, dtype=np.float64)
+    x_stat = np.zeros(5, dtype=np.float64)
+    y_stat = np.zeros(5, dtype=np.float64)
+    u_stat = np.zeros(5, dtype=np.float64)
+    stat_map = {"x": x_stat, "y": y_stat, "u": u_stat}
+
+    for i, tag in enumerate(("x", "y")):
+        if tag in fit_result and default_det:
+            det_fit = fit_result[tag].detectors.get(default_det)
+            if det_fit is not None:
+                mean_beam = stage_to_beam(
+                    np.array([det_fit.mean]), tag, metadata.install_angle
+                )[0]
+                stats[i] = mean_beam
+                stats[i + 2] = det_fit.sigma
+                stat_map[tag][1] = mean_beam
+                stat_map[tag][2] = det_fit.sigma
+
+    # XY correlation from u-plane if available
+    if "u" in fit_result and default_det:
+        u_fit = fit_result["u"].detectors.get(default_det)
+        if u_fit is not None:
+            sigma_u = u_fit.sigma
+            sigma_x = stats[2] if stats[2] > 0 else 0.0
+            sigma_y = stats[3] if stats[3] > 0 else 0.0
+            stats[4] = (sigma_x**2 + sigma_y**2 - sigma_u**2) / 2.0
+            stat_map["u"][1] = stage_to_beam(
+                np.array([u_fit.mean]), "u", metadata.install_angle
+            )[0]
+            stat_map["u"][2] = sigma_u
+
+    # SUM: integrate signal for each profile
+    for tag in ("x", "y", "u"):
+        if tag in result.profiles and default_det:
+            det_data = result.profiles[tag].detectors.get(default_det)
+            if det_data is not None and len(det_data.values) > 1:
+                p = pos[tag]
+                if len(p) > 1:
+                    dx = np.mean(np.abs(np.diff(p)))
+                    stat_map[tag][0] = float(np.sum(det_data.values) * dx)
+
+    stats[5] = stat_map["x"][0]
+
+    # Build prof arrays: [3 x N] = [positions; signal; fit_curve]
+    beam_entry: dict[str, Any] = {
+        "method": method_name,
+        "stats": stats.reshape(1, 6),
+        "statsStd": np.zeros((1, 6), dtype=np.float64),
+        "xStat": x_stat.reshape(1, 5),
+        "xStatStd": np.zeros((1, 5), dtype=np.float64),
+        "yStat": y_stat.reshape(1, 5),
+        "yStatStd": np.zeros((1, 5), dtype=np.float64),
+        "uStat": u_stat.reshape(1, 5),
+        "uStatStd": np.zeros((1, 5), dtype=np.float64),
+    }
+
+    for tag in ("x", "y", "u"):
+        prof_key = f"prof{tag}"
+        if tag in result.profiles and tag in fit_result and default_det:
+            det_fit = fit_result[tag].detectors.get(default_det)
+            p = pos[tag]
+            s = signal[tag]
+            if det_fit is not None and len(p) > 0:
+                fit_curve = np.interp(p, det_fit.positions, det_fit.curve)
+                beam_entry[prof_key] = np.vstack([p, s, fit_curve])
+            else:
+                beam_entry[prof_key] = np.zeros((3, 0), dtype=np.float64)
+        else:
+            beam_entry[prof_key] = np.zeros((3, 0), dtype=np.float64)
+
+    # scipy.io.savemat represents struct arrays as object arrays of dicts
+    beam_array = np.empty((1, 1), dtype=object)
+    beam_array[0, 0] = beam_entry
+    return beam_array
+
+
+def _build_beam_pv(wire_name: str, beam: np.ndarray) -> np.ndarray:
+    """Build MATLAB-compatible beamPV struct array."""
+    beam_entry = beam[0, 0]
+    stats = beam_entry["stats"].ravel()
+
+    names = [
+        f"{wire_name}:X",
+        f"{wire_name}:Y",
+        f"{wire_name}:XRMS",
+        f"{wire_name}:YRMS",
+        f"{wire_name}:XY",
+        f"{wire_name}:SUM",
+    ]
+    descs = [
+        "X position",
+        "Y position",
+        "X rms",
+        "Y rms",
+        "XY corr",
+        "profile intensity",
+    ]
+    egus = ["um", "um", "um", "um", "um^2", "cts"]
+
+    pv_array = np.empty((6, 1), dtype=object)
+    for i in range(6):
+        pv_array[i, 0] = {
+            "name": names[i],
+            "val": np.float64(stats[i]),
+            "desc": descs[i],
+            "egu": egus[i],
+        }
+    return pv_array
+
+
+def _fetch_rmat(
+    wire_name: str,
+    bpm_keys: list[str],
+    beampath: str | None,
+    physics_model: str,
+) -> np.ndarray:
+    """Fetch R-matrices from the optics model (requires network)."""
+    from lcls_tools.common.devices.reader import create_wire
+
+    device = create_wire(wire_name)
+    rmat_list = []
+    for bpm in bpm_keys:
+        try:
+            rmat = device.get_rmat(bpm, model=physics_model)
+            rmat_list.append(rmat[:4, :6])
+        except Exception:
+            rmat_list.append(np.zeros((4, 6), dtype=np.float64))
+
+    return (
+        np.stack(rmat_list, axis=2)
+        if rmat_list
+        else np.zeros((4, 6, 0), dtype=np.float64)
+    )

--- a/slac_measurements/wires/analysis/mat_export.py
+++ b/slac_measurements/wires/analysis/mat_export.py
@@ -26,10 +26,29 @@ def datetime_to_matlab_datenum(dt: datetime) -> float:
     return MATLAB_EPOCH_OFFSET + (dt - epoch).total_seconds() / 86400.0
 
 
+def _build_name_map_from_db(mad_names: list[str]) -> dict[str, str]:
+    """Attempt to build MAD→EPICS name map using slac_db."""
+    try:
+        import slac_db.device
+
+        name_map = {}
+        for mad_name in mad_names:
+            try:
+                epics_name = slac_db.device.get_attribute(mad_name, "cs_name")
+                if epics_name:
+                    name_map[mad_name] = epics_name
+            except Exception:
+                pass
+        return name_map
+    except ImportError:
+        return {}
+
+
 def analysis_result_to_mat(
     result: WireMeasurementAnalysisResult,
     filepath: str,
     *,
+    name_map: dict[str, str] | None = None,
     include_rmat: bool = False,
     physics_model: str = "BLEM",
 ) -> str:
@@ -45,6 +64,12 @@ def analysis_result_to_mat(
         The analysis result to export.
     filepath : str
         Output ``.mat`` file path.
+    name_map : dict[str, str], optional
+        Mapping from MAD names (as stored in the Python result) to EPICS
+        names (as expected by MATLAB).  E.g.
+        ``{"WS28744": "WIRE:LI28:744", "PMT29150": "PMT:LI29:150"}``.
+        If None, attempts to look up names via ``slac_db`` (requires DB
+        access); falls back to using MAD names unchanged.
     include_rmat : bool
         Whether to fetch R-matrices from the optics model.  Requires
         network access.  Default False.
@@ -61,11 +86,23 @@ def analysis_result_to_mat(
     metadata = result.collection_result.metadata
     raw_data = result.collection_result.raw_data
 
+    # Build or auto-detect MAD→EPICS name map
+    if name_map is None:
+        all_mad_names = [metadata.wire_name]
+        if metadata.detectors:
+            all_mad_names.extend(metadata.detectors)
+        all_mad_names.extend(k for k in raw_data.keys() if k != metadata.wire_name)
+        name_map = _build_name_map_from_db(all_mad_names)
+
+    def _epics(mad_name: str) -> str:
+        return name_map.get(mad_name, mad_name)
+
     data: dict[str, Any] = {}
 
     # --- Scalar / string fields ---
-    data["name"] = metadata.wire_name
-    data["wireName"] = metadata.wire_name
+    wire_epics = _epics(metadata.wire_name)
+    data["name"] = wire_epics
+    data["wireName"] = wire_epics
     data["wireMode"] = "wire"
     data["beampath"] = metadata.beampath or ""
     data["status"] = np.bool_(True)
@@ -101,14 +138,18 @@ def analysis_result_to_mat(
     # --- Device lists and raw data ---
     pmt_keys, bpm_keys, toro_keys = _classify_raw_data_keys(raw_data, metadata)
 
+    pmt_epics = [_epics(k) for k in pmt_keys]
+    bpm_epics = [_epics(k) for k in bpm_keys]
+    toro_epics = [_epics(k) for k in toro_keys]
+
     data["PMTList"] = (
-        np.array(pmt_keys, dtype=object) if pmt_keys else np.array([], dtype=object)
+        np.array(pmt_epics, dtype=object) if pmt_epics else np.array([], dtype=object)
     )
     data["BPMList"] = (
-        np.array(bpm_keys, dtype=object) if bpm_keys else np.array([], dtype=object)
+        np.array(bpm_epics, dtype=object) if bpm_epics else np.array([], dtype=object)
     )
     data["toroList"] = (
-        np.array(toro_keys, dtype=object) if toro_keys else np.array([], dtype=object)
+        np.array(toro_epics, dtype=object) if toro_epics else np.array([], dtype=object)
     )
 
     wire_key = metadata.wire_name
@@ -229,7 +270,7 @@ def analysis_result_to_mat(
     data["beam"] = _build_beam_struct(result, pos, signal)
 
     # --- beamPV ---
-    data["beamPV"] = _build_beam_pv(metadata.wire_name, data["beam"])
+    data["beamPV"] = _build_beam_pv(wire_epics, data["beam"])
 
     scipy.io.savemat(filepath, {"data": data}, do_compression=True, oned_as="row")
     return filepath

--- a/slac_measurements/wires/analysis/mat_export.py
+++ b/slac_measurements/wires/analysis/mat_export.py
@@ -114,11 +114,11 @@ def analysis_result_to_mat(
     wire_key = metadata.wire_name
     if wire_key in raw_data:
         wire_arr = np.asarray(raw_data[wire_key], dtype=np.float64)
-        data["wireData"] = wire_arr.reshape(1, -1, 1)
+        data["wireData"] = wire_arr.reshape(1, -1)
         data["wireMask"] = np.ones_like(data["wireData"], dtype=np.float64)
     else:
-        data["wireData"] = np.zeros((1, 0, 1), dtype=np.float64)
-        data["wireMask"] = np.zeros((1, 0, 1), dtype=np.float64)
+        data["wireData"] = np.zeros((1, 0), dtype=np.float64)
+        data["wireMask"] = np.zeros((1, 0), dtype=np.float64)
 
     n_pulses = data["wireData"].shape[1]
 
@@ -127,9 +127,9 @@ def analysis_result_to_mat(
         for key in pmt_keys:
             arr = np.asarray(raw_data.get(key, np.zeros(n_pulses)), dtype=np.float64)
             pmt_arrays.append(arr.ravel())
-        data["PMTData"] = np.array(pmt_arrays).reshape(len(pmt_keys), n_pulses, 1)
+        data["PMTData"] = np.array(pmt_arrays).reshape(len(pmt_keys), n_pulses)
     else:
-        data["PMTData"] = np.zeros((0, n_pulses, 1), dtype=np.float64)
+        data["PMTData"] = np.zeros((1, n_pulses), dtype=np.float64)
 
     if bpm_keys:
         bpmx_arrays = []
@@ -150,11 +150,11 @@ def analysis_result_to_mat(
             else:
                 bpmx_arrays.append(np.zeros(n_pulses, dtype=np.float64))
                 bpmy_arrays.append(np.zeros(n_pulses, dtype=np.float64))
-        data["BPMXData"] = np.array(bpmx_arrays).reshape(len(bpm_keys), n_pulses, 1)
-        data["BPMYData"] = np.array(bpmy_arrays).reshape(len(bpm_keys), n_pulses, 1)
+        data["BPMXData"] = np.array(bpmx_arrays).reshape(len(bpm_keys), n_pulses)
+        data["BPMYData"] = np.array(bpmy_arrays).reshape(len(bpm_keys), n_pulses)
     else:
-        data["BPMXData"] = np.zeros((0, n_pulses, 1), dtype=np.float64)
-        data["BPMYData"] = np.zeros((0, n_pulses, 1), dtype=np.float64)
+        data["BPMXData"] = np.zeros((0, n_pulses), dtype=np.float64)
+        data["BPMYData"] = np.zeros((0, n_pulses), dtype=np.float64)
 
     if toro_keys:
         toro_arrays = []
@@ -164,9 +164,20 @@ def analysis_result_to_mat(
                     raw_data.get(key, np.zeros(n_pulses)), dtype=np.float64
                 ).ravel()
             )
-        data["toroData"] = np.array(toro_arrays).reshape(len(toro_keys), n_pulses, 1)
+        data["toroData"] = np.array(toro_arrays).reshape(len(toro_keys), n_pulses)
     else:
-        data["toroData"] = np.zeros((0, n_pulses, 1), dtype=np.float64)
+        # GUI always expects at least one toroid row
+        area = metadata.area or "LI21"
+        toro_keys = [f"TORO:{area}:1"]
+        data["toroList"] = np.array(toro_keys, dtype=object)
+        data["toroData"] = np.ones((1, n_pulses), dtype=np.float64) * 1e9
+
+    data["selectToro"] = np.float64(1.0)
+    data["selectBPM"] = (
+        np.ones((1, len(bpm_keys)), dtype=np.float64)
+        if bpm_keys
+        else np.zeros((1, 0), dtype=np.float64)
+    )
 
     # --- R-matrices (optional) ---
     if include_rmat and bpm_keys:

--- a/slac_measurements/wires/analysis/mat_export.py
+++ b/slac_measurements/wires/analysis/mat_export.py
@@ -177,12 +177,12 @@ def analysis_result_to_mat(
         # signal at duplicate positions — matches what Python analysis does.
         unique_pos, inverse = np.unique(wire_arr, return_inverse=True)
         data["wireData"] = unique_pos.reshape(1, -1)
-        data["wireMask"] = np.ones_like(data["wireData"], dtype=np.float64)
+        data["wireMask"] = np.ones_like(data["wireData"], dtype=np.bool_)
     else:
         unique_pos = np.zeros(0, dtype=np.float64)
         inverse = np.array([], dtype=int)
         data["wireData"] = np.zeros((1, 0), dtype=np.float64)
-        data["wireMask"] = np.zeros((1, 0), dtype=np.float64)
+        data["wireMask"] = np.zeros((1, 0), dtype=np.bool_)
 
     n_pulses = data["wireData"].shape[1]
 

--- a/slac_measurements/wires/analysis/mat_export.py
+++ b/slac_measurements/wires/analysis/mat_export.py
@@ -28,20 +28,36 @@ def datetime_to_matlab_datenum(dt: datetime) -> float:
 
 def _build_name_map_from_db(mad_names: list[str]) -> dict[str, str]:
     """Attempt to build MAD→EPICS name map using slac_db."""
+    import warnings
+
     try:
         import slac_db.device
-
-        name_map = {}
-        for mad_name in mad_names:
-            try:
-                epics_name = slac_db.device.get_attribute(mad_name, "cs_name")
-                if epics_name:
-                    name_map[mad_name] = epics_name
-            except Exception:
-                pass
-        return name_map
     except ImportError:
+        warnings.warn(
+            "slac_db not available; MAD names will not be converted to EPICS. "
+            "Pass name_map explicitly to to_mat().",
+            stacklevel=3,
+        )
         return {}
+
+    name_map = {}
+    for mad_name in mad_names:
+        try:
+            epics_name = slac_db.device.get_attribute(mad_name, "cs_name")
+            if epics_name:
+                name_map[mad_name] = epics_name
+        except Exception as exc:
+            warnings.warn(
+                f"Failed to look up EPICS name for '{mad_name}': {exc}",
+                stacklevel=3,
+            )
+    if not name_map:
+        warnings.warn(
+            "slac_db lookup returned no EPICS names. "
+            "Pass name_map explicitly to to_mat().",
+            stacklevel=3,
+        )
+    return name_map
 
 
 def analysis_result_to_mat(

--- a/slac_measurements/wires/analysis/mat_export.py
+++ b/slac_measurements/wires/analysis/mat_export.py
@@ -26,13 +26,15 @@ def datetime_to_matlab_datenum(dt: datetime) -> float:
     return MATLAB_EPOCH_OFFSET + (dt - epoch).total_seconds() / 86400.0
 
 
-def _build_name_map_from_db(mad_names: list[str]) -> dict[str, str]:
-    """Attempt to build MAD→EPICS name map using slac_db."""
+def _build_name_map(mad_names: list[str]) -> dict[str, str]:
+    """Build MAD→EPICS name map from slac_db YAML device configs."""
     import warnings
 
     try:
-        import slac_db.device
-    except ImportError:
+        import slac_db.config
+
+        yaml_dir = slac_db.config.yaml()
+    except (ImportError, Exception):
         warnings.warn(
             "slac_db not available; MAD names will not be converted to EPICS. "
             "Pass name_map explicitly to to_mat().",
@@ -40,21 +42,57 @@ def _build_name_map_from_db(mad_names: list[str]) -> dict[str, str]:
         )
         return {}
 
-    name_map = {}
-    for mad_name in mad_names:
-        try:
-            epics_name = slac_db.device.get_attribute(mad_name, "cs_name")
-            if epics_name:
-                name_map[mad_name] = epics_name
-        except Exception as exc:
-            warnings.warn(
-                f"Failed to look up EPICS name for '{mad_name}': {exc}",
-                stacklevel=3,
-            )
-    if not name_map:
+    import pathlib
+
+    import yaml
+
+    mad_set = set(mad_names)
+    name_map: dict[str, str] = {}
+
+    yaml_path = pathlib.Path(yaml_dir)
+    if not yaml_path.is_dir():
         warnings.warn(
-            "slac_db lookup returned no EPICS names. "
+            f"slac_db YAML directory not found: {yaml_path}. "
             "Pass name_map explicitly to to_mat().",
+            stacklevel=3,
+        )
+        return {}
+
+    for yaml_file in yaml_path.glob("*.yaml"):
+        if not mad_set - set(name_map.keys()):
+            break
+        try:
+            with open(yaml_file) as f:
+                area_data = yaml.safe_load(f)
+        except Exception:
+            continue
+        if not isinstance(area_data, dict):
+            continue
+        for device_type_data in area_data.values():
+            if not isinstance(device_type_data, dict):
+                continue
+            for mad_name, device_info in device_type_data.items():
+                if mad_name not in mad_set or mad_name in name_map:
+                    continue
+                if not isinstance(device_info, dict):
+                    continue
+                ctrl = device_info.get("controls_information", {})
+                if ctrl.get("control_name"):
+                    name_map[mad_name] = ctrl["control_name"]
+                    continue
+                pvs = ctrl.get("PVs", {})
+                if pvs:
+                    first_pv = next(iter(pvs.values()), "")
+                    if first_pv and ":" in first_pv:
+                        parts = first_pv.split(":")
+                        if len(parts) >= 3:
+                            name_map[mad_name] = ":".join(parts[:3])
+
+    missing = mad_set - set(name_map.keys())
+    if missing:
+        warnings.warn(
+            f"Could not find EPICS names for: {sorted(missing)}. "
+            "These will use MAD names. Pass name_map to override.",
             stacklevel=3,
         )
     return name_map
@@ -108,7 +146,7 @@ def analysis_result_to_mat(
         if metadata.detectors:
             all_mad_names.extend(metadata.detectors)
         all_mad_names.extend(k for k in raw_data.keys() if k != metadata.wire_name)
-        name_map = _build_name_map_from_db(all_mad_names)
+        name_map = _build_name_map(all_mad_names)
 
     def _epics(mad_name: str) -> str:
         return name_map.get(mad_name, mad_name)

--- a/slac_measurements/wires/analysis/mat_export.py
+++ b/slac_measurements/wires/analysis/mat_export.py
@@ -168,12 +168,19 @@ def analysis_result_to_mat(
         np.array(toro_epics, dtype=object) if toro_epics else np.array([], dtype=object)
     )
 
+    # Use the longest active profile to determine n_pulses for raw arrays.
+    # Export unique positions so MATLAB's reprocessing (interp1) won't fail.
     wire_key = metadata.wire_name
     if wire_key in raw_data:
         wire_arr = np.asarray(raw_data[wire_key], dtype=np.float64)
-        data["wireData"] = wire_arr.reshape(1, -1)
+        # Deduplicate: keep only unique positions (sorted), averaging
+        # signal at duplicate positions — matches what Python analysis does.
+        unique_pos, inverse = np.unique(wire_arr, return_inverse=True)
+        data["wireData"] = unique_pos.reshape(1, -1)
         data["wireMask"] = np.ones_like(data["wireData"], dtype=np.float64)
     else:
+        unique_pos = np.zeros(0, dtype=np.float64)
+        inverse = np.array([], dtype=int)
         data["wireData"] = np.zeros((1, 0), dtype=np.float64)
         data["wireMask"] = np.zeros((1, 0), dtype=np.float64)
 
@@ -182,11 +189,35 @@ def analysis_result_to_mat(
     if pmt_keys:
         pmt_arrays = []
         for key in pmt_keys:
-            arr = np.asarray(raw_data.get(key, np.zeros(n_pulses)), dtype=np.float64)
-            pmt_arrays.append(arr.ravel())
+            arr = np.asarray(
+                raw_data.get(key, np.zeros(len(inverse))), dtype=np.float64
+            ).ravel()
+            if len(inverse) > 0 and len(arr) == len(inverse):
+                # Average signal at duplicate positions
+                deduped = np.zeros(n_pulses, dtype=np.float64)
+                counts = np.zeros(n_pulses, dtype=np.float64)
+                np.add.at(deduped, inverse, arr)
+                np.add.at(counts, inverse, 1.0)
+                counts[counts == 0] = 1.0
+                pmt_arrays.append(deduped / counts)
+            else:
+                pmt_arrays.append(
+                    arr[:n_pulses] if len(arr) >= n_pulses else np.zeros(n_pulses)
+                )
         data["PMTData"] = np.array(pmt_arrays).reshape(len(pmt_keys), n_pulses)
     else:
         data["PMTData"] = np.zeros((1, n_pulses), dtype=np.float64)
+
+    def _dedup_array(arr_raw, inv, n_out):
+        """Average raw array values at duplicate wire positions."""
+        if len(inv) > 0 and len(arr_raw) == len(inv):
+            deduped = np.zeros(n_out, dtype=np.float64)
+            counts = np.zeros(n_out, dtype=np.float64)
+            np.add.at(deduped, inv, arr_raw)
+            np.add.at(counts, inv, 1.0)
+            counts[counts == 0] = 1.0
+            return deduped / counts
+        return arr_raw[:n_out] if len(arr_raw) >= n_out else np.zeros(n_out)
 
     if bpm_keys:
         bpmx_arrays = []
@@ -194,16 +225,14 @@ def analysis_result_to_mat(
         for key in bpm_keys:
             bpm_val = raw_data.get(key, {})
             if isinstance(bpm_val, dict):
-                bpmx_arrays.append(
-                    np.asarray(
-                        bpm_val.get("x", np.zeros(n_pulses)), dtype=np.float64
-                    ).ravel()
-                )
-                bpmy_arrays.append(
-                    np.asarray(
-                        bpm_val.get("y", np.zeros(n_pulses)), dtype=np.float64
-                    ).ravel()
-                )
+                raw_x = np.asarray(
+                    bpm_val.get("x", np.zeros(len(inverse))), dtype=np.float64
+                ).ravel()
+                raw_y = np.asarray(
+                    bpm_val.get("y", np.zeros(len(inverse))), dtype=np.float64
+                ).ravel()
+                bpmx_arrays.append(_dedup_array(raw_x, inverse, n_pulses))
+                bpmy_arrays.append(_dedup_array(raw_y, inverse, n_pulses))
             else:
                 bpmx_arrays.append(np.zeros(n_pulses, dtype=np.float64))
                 bpmy_arrays.append(np.zeros(n_pulses, dtype=np.float64))
@@ -216,11 +245,10 @@ def analysis_result_to_mat(
     if toro_keys:
         toro_arrays = []
         for key in toro_keys:
-            toro_arrays.append(
-                np.asarray(
-                    raw_data.get(key, np.zeros(n_pulses)), dtype=np.float64
-                ).ravel()
-            )
+            raw_t = np.asarray(
+                raw_data.get(key, np.zeros(len(inverse))), dtype=np.float64
+            ).ravel()
+            toro_arrays.append(_dedup_array(raw_t, inverse, n_pulses))
         data["toroData"] = np.array(toro_arrays).reshape(len(toro_keys), n_pulses)
     else:
         # GUI always expects at least one toroid row

--- a/slac_measurements/wires/analysis/mat_export.py
+++ b/slac_measurements/wires/analysis/mat_export.py
@@ -6,7 +6,6 @@ Produces files compatible with the MATLAB wirescan_gui (File > Open).
 from __future__ import annotations
 
 import json
-import os
 import pathlib
 import warnings
 from datetime import datetime, timezone
@@ -16,14 +15,10 @@ import numpy as np
 import scipy.io
 import yaml
 
-try:
-    import slac_db.config
+import slac_db.config
 
-    _SLAC_DB_YAML: str | None = slac_db.config.yaml()
-    _SLAC_DB_PACKAGE_DATA: pathlib.Path | None = slac_db.config.package_data()
-except (ImportError, Exception):
-    _SLAC_DB_YAML = None
-    _SLAC_DB_PACKAGE_DATA = None
+_SLAC_DB_YAML: str = slac_db.config.yaml()
+_SLAC_DB_PACKAGE_DATA: pathlib.Path = slac_db.config.package_data()
 
 if TYPE_CHECKING:
     from slac_measurements.wires.analysis.results import (
@@ -64,14 +59,6 @@ def _dedup_array(raw: np.ndarray, inverse: np.ndarray, n_out: int) -> np.ndarray
 
 def _build_name_map(mad_names: list[str]) -> dict[str, str]:
     """Build MAD→EPICS name map from slac_db YAML device configs."""
-    if _SLAC_DB_YAML is None:
-        warnings.warn(
-            "slac_db not available; MAD names will not be converted to EPICS. "
-            "Pass name_map explicitly to to_mat().",
-            stacklevel=3,
-        )
-        return {}
-
     mad_set = set(mad_names)
     name_map: dict[str, str] = {}
 
@@ -141,18 +128,12 @@ def _build_auto_name_map(metadata: Any, raw_data: dict) -> dict[str, str]:
 
 def _load_wirescan_config() -> dict | None:
     """Load wirescan_config.json from known locations."""
-    config_locations = [
-        pathlib.Path("/usr/local/lcls/tools/matlab/toolbox/wirescan_config.json"),
-        pathlib.Path(os.environ.get("MATLABPATH", "")) / "wirescan_config.json",
-        pathlib.Path.home() / "Documents" / "toolbox" / "wirescan_config.json",
-    ]
-    for config_path in config_locations:
-        if config_path.exists():
-            try:
-                with open(config_path) as f:
-                    return json.load(f)
-            except Exception:
-                continue
+    config_path = pathlib.Path(
+        "/usr/local/lcls/tools/matlab/toolbox/wirescan_config.json"
+    )
+    if config_path.exists():
+        with open(config_path) as f:
+            return json.load(f)
     return None
 
 
@@ -181,13 +162,12 @@ def _get_sector_pmt_list(area: str, cfg: dict | None = None) -> list[str]:
             if pmt_list:
                 return pmt_list
 
-    if _SLAC_DB_PACKAGE_DATA is not None:
-        meta_path = _SLAC_DB_PACKAGE_DATA / "wire_area_metadata.yaml"
-        if meta_path.exists():
-            with open(meta_path) as f:
-                area_meta = yaml.safe_load(f)
-            if area in area_meta and "detectors" in area_meta[area]:
-                return [d.split(":")[0] for d in area_meta[area]["detectors"]]
+    meta_path = _SLAC_DB_PACKAGE_DATA / "wire_area_metadata.yaml"
+    if meta_path.exists():
+        with open(meta_path) as f:
+            area_meta = yaml.safe_load(f)
+        if area in area_meta and "detectors" in area_meta[area]:
+            return [d.split(":")[0] for d in area_meta[area]["detectors"]]
     return []
 
 

--- a/slac_measurements/wires/analysis/mat_export.py
+++ b/slac_measurements/wires/analysis/mat_export.py
@@ -469,6 +469,33 @@ def _build_beam_pv(wire_name: str, beam: np.ndarray) -> np.ndarray:
     return pv_array
 
 
+def _fetch_rmat_list(
+    wire_name: str, bpm_keys: list[str], beampath: str | None
+) -> np.ndarray:
+    """Fetch R-matrices from wire to each BPM via meme.model.
+
+    Returns shape (4, 6, n_bpm). Falls back to zeros on failure.
+    """
+    n_bpm = len(bpm_keys)
+    if not bpm_keys or not beampath:
+        return np.zeros((4, 6, n_bpm), dtype=np.float64)
+
+    try:
+        from meme.model import Model
+    except ImportError:
+        return np.zeros((4, 6, n_bpm), dtype=np.float64)
+
+    model = Model(beampath, model_source="BLEM", use_design=False)
+    slabs = []
+    for bpm in bpm_keys:
+        try:
+            rmat = model.get_rmat(from_device=wire_name, to_device=bpm)
+            slabs.append(rmat[:4, :6].astype(np.float64))
+        except Exception:
+            slabs.append(np.zeros((4, 6), dtype=np.float64))
+    return np.stack(slabs, axis=2)
+
+
 # ---------------------------------------------------------------------------
 # Main export function
 # ---------------------------------------------------------------------------
@@ -602,7 +629,7 @@ def analysis_result_to_mat(
             if n_bpm
             else np.zeros((1, 0), dtype=np.float64)
         ),
-        "rMatList": np.zeros((4, 6, n_bpm), dtype=np.float64),
+        "rMatList": _fetch_rmat_list(metadata.wire_name, bpm_keys, metadata.beampath),
         "pos": pos,
         "signal": signal,
         "selectPMT": select_pmt,

--- a/slac_measurements/wires/analysis/mat_export.py
+++ b/slac_measurements/wires/analysis/mat_export.py
@@ -99,20 +99,41 @@ def _build_name_map(mad_names: list[str]) -> dict[str, str]:
 
 
 def _get_sector_pmt_list(area: str) -> list[str]:
-    """Get the full PMT/detector list for a sector from wire_area_metadata.yaml."""
+    """Get the full PMT/detector list for a sector from wirescan_config.json."""
+    import pathlib
+
+    # Try wirescan_config.json (authoritative for the MATLAB GUI dropdown)
+    config_locations = [
+        pathlib.Path("/usr/local/lcls/tools/matlab/toolbox/wirescan_config.json"),
+        pathlib.Path.home() / "Documents" / "toolbox" / "wirescan_config.json",
+    ]
+    for config_path in config_locations:
+        if config_path.exists():
+            try:
+                import json
+
+                with open(config_path) as f:
+                    cfg = json.load(f)
+                sectors = cfg.get("sectors", {})
+                if isinstance(sectors, dict) and area in sectors:
+                    pmt_list = sectors[area].get("PMTMADList", [])
+                    if pmt_list:
+                        return pmt_list
+            except Exception:
+                continue
+
+    # Fallback: wire_area_metadata.yaml from slac_db
     try:
         import slac_db.config
 
         import yaml
 
         meta_path = slac_db.config.package_data() / "wire_area_metadata.yaml"
-        if not meta_path.exists():
-            return []
-        with open(meta_path) as f:
-            area_meta = yaml.safe_load(f)
-        if area in area_meta and "detectors" in area_meta[area]:
-            # Format is "PMT29150:LI29" — take the MAD name before the colon
-            return [d.split(":")[0] for d in area_meta[area]["detectors"]]
+        if meta_path.exists():
+            with open(meta_path) as f:
+                area_meta = yaml.safe_load(f)
+            if area in area_meta and "detectors" in area_meta[area]:
+                return [d.split(":")[0] for d in area_meta[area]["detectors"]]
     except Exception:
         pass
     return []

--- a/slac_measurements/wires/analysis/mat_export.py
+++ b/slac_measurements/wires/analysis/mat_export.py
@@ -15,9 +15,10 @@ import numpy as np
 import scipy.io
 import yaml
 
+import pykern.sql_db
 import slac_db.config
+import slac_db.device
 
-_SLAC_DB_YAML: str = slac_db.config.yaml()
 _SLAC_DB_PACKAGE_DATA: pathlib.Path = slac_db.config.package_data()
 
 if TYPE_CHECKING:
@@ -46,50 +47,17 @@ def datetime_to_matlab_datenum(dt: datetime) -> float:
 
 
 def _build_name_map(mad_names: list[str]) -> dict[str, str]:
-    """Build MAD→EPICS name map from slac_db YAML device configs."""
-    mad_set = set(mad_names)
+    """Build MAD→EPICS name map from slac_db device database."""
     name_map: dict[str, str] = {}
-
-    yaml_path = pathlib.Path(_SLAC_DB_YAML)
-    if not yaml_path.is_dir():
-        warnings.warn(
-            f"slac_db YAML directory not found: {yaml_path}. "
-            "Pass name_map explicitly to to_mat().",
-            stacklevel=3,
-        )
-        return {}
-
-    for yaml_file in yaml_path.glob("*.yaml"):
-        if not mad_set - set(name_map.keys()):
-            break
+    for mad_name in mad_names:
         try:
-            with open(yaml_file) as f:
-                area_data = yaml.safe_load(f)
-        except Exception:
+            cs_name = slac_db.device.get_attribute(mad_name, "cs_name")
+            if cs_name:
+                name_map[mad_name] = cs_name
+        except pykern.sql_db.NoRows:
             continue
-        if not isinstance(area_data, dict):
-            continue
-        for device_type_data in area_data.values():
-            if not isinstance(device_type_data, dict):
-                continue
-            for mad_name, device_info in device_type_data.items():
-                if mad_name not in mad_set or mad_name in name_map:
-                    continue
-                if not isinstance(device_info, dict):
-                    continue
-                ctrl = device_info.get("controls_information", {})
-                if ctrl.get("control_name"):
-                    name_map[mad_name] = ctrl["control_name"]
-                    continue
-                pvs = ctrl.get("PVs", {})
-                if pvs:
-                    first_pv = next(iter(pvs.values()), "")
-                    if first_pv and ":" in first_pv:
-                        parts = first_pv.split(":")
-                        if len(parts) >= 3:
-                            name_map[mad_name] = ":".join(parts[:3])
 
-    missing = mad_set - set(name_map.keys())
+    missing = set(mad_names) - set(name_map.keys())
     if missing:
         warnings.warn(
             f"Could not find EPICS names for: {sorted(missing)}. "

--- a/slac_measurements/wires/analysis/mat_export.py
+++ b/slac_measurements/wires/analysis/mat_export.py
@@ -247,6 +247,10 @@ def analysis_result_to_mat(
     full_pmt_keys = _get_sector_pmt_list(metadata.area)
     if full_pmt_keys:
         pmt_keys_ordered = full_pmt_keys
+        # Ensure name_map covers config-only detectors (e.g. PMT28750)
+        unmapped = [k for k in full_pmt_keys if k not in name_map]
+        if unmapped:
+            name_map.update(_build_name_map(unmapped))
     else:
         pmt_keys_ordered = pmt_keys
         base_to_collected = {k: k for k in pmt_keys}

--- a/slac_measurements/wires/analysis/mat_export.py
+++ b/slac_measurements/wires/analysis/mat_export.py
@@ -103,8 +103,11 @@ def _get_sector_pmt_list(area: str) -> list[str]:
     import pathlib
 
     # Try wirescan_config.json (authoritative for the MATLAB GUI dropdown)
+    import os
+
     config_locations = [
         pathlib.Path("/usr/local/lcls/tools/matlab/toolbox/wirescan_config.json"),
+        pathlib.Path(os.environ.get("MATLABPATH", "")) / "wirescan_config.json",
         pathlib.Path.home() / "Documents" / "toolbox" / "wirescan_config.json",
     ]
     for config_path in config_locations:

--- a/slac_measurements/wires/analysis/mat_export.py
+++ b/slac_measurements/wires/analysis/mat_export.py
@@ -17,6 +17,11 @@ if TYPE_CHECKING:
     )
 
 
+# ---------------------------------------------------------------------------
+# Small utilities
+# ---------------------------------------------------------------------------
+
+
 def datetime_to_matlab_datenum(dt: datetime) -> float:
     """Convert a Python datetime to a MATLAB datenum (days since Jan 0, 0000)."""
     MATLAB_EPOCH_OFFSET = 719529.0  # datenum('1970-01-01')
@@ -24,6 +29,23 @@ def datetime_to_matlab_datenum(dt: datetime) -> float:
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
     return MATLAB_EPOCH_OFFSET + (dt - epoch).total_seconds() / 86400.0
+
+
+def _dedup_array(raw: np.ndarray, inverse: np.ndarray, n_out: int) -> np.ndarray:
+    """Average raw array values at duplicate wire positions."""
+    if len(inverse) > 0 and len(raw) == len(inverse):
+        deduped = np.zeros(n_out, dtype=np.float64)
+        counts = np.zeros(n_out, dtype=np.float64)
+        np.add.at(deduped, inverse, raw)
+        np.add.at(counts, inverse, 1.0)
+        counts[counts == 0] = 1.0
+        return deduped / counts
+    return raw[:n_out] if len(raw) >= n_out else np.zeros(n_out, dtype=np.float64)
+
+
+# ---------------------------------------------------------------------------
+# Name map (MAD → EPICS)
+# ---------------------------------------------------------------------------
 
 
 def _build_name_map(mad_names: list[str]) -> dict[str, str]:
@@ -98,6 +120,21 @@ def _build_name_map(mad_names: list[str]) -> dict[str, str]:
     return name_map
 
 
+def _build_auto_name_map(metadata: Any, raw_data: dict) -> dict[str, str]:
+    """Auto-detect MAD→EPICS name map from metadata + raw_data keys."""
+    all_mad_names = [metadata.wire_name]
+    if metadata.detectors:
+        all_mad_names.extend(metadata.detectors)
+    all_mad_names.extend(k for k in raw_data.keys() if k != metadata.wire_name)
+    base_names = {n.rsplit(":", 1)[0] for n in all_mad_names}
+    return _build_name_map(list(set(all_mad_names) | base_names))
+
+
+# ---------------------------------------------------------------------------
+# Sector / config lookup
+# ---------------------------------------------------------------------------
+
+
 def _load_wirescan_config() -> dict | None:
     """Load wirescan_config.json from known locations."""
     import json
@@ -127,14 +164,13 @@ def _wire_to_sector(wire_mad: str, cfg: dict | None) -> str | None:
     for sector_name, sector_data in sectors.items():
         if not isinstance(sector_data, dict):
             continue
-        wire_list = sector_data.get("wireMADList", [])
-        if wire_mad in wire_list:
+        if wire_mad in sector_data.get("wireMADList", []):
             return sector_name
     return None
 
 
 def _get_sector_pmt_list(area: str, cfg: dict | None = None) -> list[str]:
-    """Get the full PMT/detector list for a sector from wirescan_config.json."""
+    """Get the full PMT/detector list for a sector."""
     if cfg is None:
         cfg = _load_wirescan_config()
 
@@ -145,7 +181,6 @@ def _get_sector_pmt_list(area: str, cfg: dict | None = None) -> list[str]:
             if pmt_list:
                 return pmt_list
 
-    # Fallback: wire_area_metadata.yaml from slac_db
     try:
         import slac_db.config
 
@@ -162,295 +197,9 @@ def _get_sector_pmt_list(area: str, cfg: dict | None = None) -> list[str]:
     return []
 
 
-def analysis_result_to_mat(
-    result: WireMeasurementAnalysisResult,
-    filepath: str,
-    *,
-    name_map: dict[str, str] | None = None,
-    include_rmat: bool = False,
-    physics_model: str = "BLEM",
-) -> str:
-    """Export a WireMeasurementAnalysisResult as a MATLAB .mat file.
-
-    The output file contains a single ``data`` struct variable matching
-    the layout produced by the MATLAB ``wirescan_gui`` ``dataSave``
-    function, so it can be loaded directly with ``File > Open``.
-
-    Parameters
-    ----------
-    result : WireMeasurementAnalysisResult
-        The analysis result to export.
-    filepath : str
-        Output ``.mat`` file path.
-    name_map : dict[str, str], optional
-        Mapping from MAD names (as stored in the Python result) to EPICS
-        names (as expected by MATLAB).  E.g.
-        ``{"WS28744": "WIRE:LI28:744", "PMT29150": "PMT:LI29:150"}``.
-        If None, attempts to look up names via ``slac_db`` (requires DB
-        access); falls back to using MAD names unchanged.
-    include_rmat : bool
-        Whether to fetch R-matrices from the optics model.  Requires
-        network access.  Default False.
-    physics_model : str
-        Model source for R-matrix retrieval.  Default ``"BLEM"``.
-
-    Returns
-    -------
-    str
-        Path to the saved ``.mat`` file.
-    """
-    from slac_measurements.wires.analysis.coordinates import stage_to_beam
-
-    metadata = result.collection_result.metadata
-    raw_data = result.collection_result.raw_data
-
-    # Build or auto-detect MAD→EPICS name map
-    if name_map is None:
-        all_mad_names = [metadata.wire_name]
-        if metadata.detectors:
-            all_mad_names.extend(metadata.detectors)
-        all_mad_names.extend(k for k in raw_data.keys() if k != metadata.wire_name)
-        # Also include base MAD names (strip beampath suffix) for lookup
-        base_names = {n.rsplit(":", 1)[0] for n in all_mad_names}
-        all_mad_names = list(set(all_mad_names) | base_names)
-        name_map = _build_name_map(all_mad_names)
-
-    def _epics(mad_name: str) -> str:
-        return name_map.get(mad_name, mad_name)
-
-    data: dict[str, Any] = {}
-
-    # --- Scalar / string fields ---
-    wire_epics = _epics(metadata.wire_name)
-    data["name"] = wire_epics
-    data["wireName"] = wire_epics
-    data["wireMode"] = "wire"
-    data["beampath"] = metadata.beampath or ""
-    data["status"] = np.bool_(True)
-
-    if metadata.timestamp is not None:
-        data["ts"] = datetime_to_matlab_datenum(metadata.timestamp)
-    else:
-        data["ts"] = np.float64(0.0)
-
-    # --- Wire geometry ---
-    data["wireAngle"] = np.float64(metadata.install_angle)
-    data["wireScanDir"] = np.float64(0.0)
-
-    wire_dir = {}
-    wire_limit = {}
-    wire_center = {}
-    wire_size = {}
-    for tag in ("x", "y", "u"):
-        wire_dir[tag] = np.bool_(tag in metadata.active_profiles)
-        if tag in metadata.scan_ranges:
-            lo, hi = metadata.scan_ranges[tag]
-            wire_limit[tag] = np.array([lo, hi], dtype=np.float64)
-        else:
-            wire_limit[tag] = np.array([0.0, 0.0], dtype=np.float64)
-        wire_center[tag] = np.float64(0.0)
-        wire_size[tag] = np.float64(12.5)
-
-    data["wireDir"] = wire_dir
-    data["wireLimit"] = wire_limit
-    data["wireCenter"] = wire_center
-    data["wireSize"] = wire_size
-
-    # --- Device lists and raw data ---
-    pmt_keys, bpm_keys, toro_keys = _classify_raw_data_keys(raw_data, metadata)
-
-    # Get the full sector PMT list so indices match the GUI dropdown.
-    # Python detector names carry a beampath suffix (e.g. "PMT29150:LI29")
-    # while the config uses short MAD names (e.g. "PMT29150").  Build a
-    # lookup from base MAD name → collected (suffixed) name for matching.
-    base_to_collected = {k.rsplit(":", 1)[0]: k for k in pmt_keys}
-    # metadata.area comes from the device DB (e.g. "L3") which doesn't match
-    # the MATLAB GUI sector names (e.g. "LI28").  Look up the wire's sector
-    # from the config's wireMADList (handles e.g. WS27644 → LI28).
-    cfg = _load_wirescan_config()
-    sector = _wire_to_sector(metadata.wire_name, cfg) or metadata.area
-    full_pmt_keys = _get_sector_pmt_list(sector, cfg)
-    if full_pmt_keys:
-        pmt_keys_ordered = full_pmt_keys
-        # Ensure name_map covers config-only detectors (e.g. PMT28750)
-        unmapped = [k for k in full_pmt_keys if k not in name_map]
-        if unmapped:
-            name_map.update(_build_name_map(unmapped))
-    else:
-        pmt_keys_ordered = pmt_keys
-        base_to_collected = {k: k for k in pmt_keys}
-
-    pmt_epics = [_epics(k) for k in pmt_keys_ordered]
-    bpm_epics = [_epics(k) for k in bpm_keys]
-    toro_epics = [_epics(k) for k in toro_keys]
-
-    data["PMTList"] = (
-        np.array(pmt_epics, dtype=object) if pmt_epics else np.array([], dtype=object)
-    )
-    data["BPMList"] = (
-        np.array(bpm_epics, dtype=object) if bpm_epics else np.array([], dtype=object)
-    )
-    data["toroList"] = (
-        np.array(toro_epics, dtype=object) if toro_epics else np.array([], dtype=object)
-    )
-
-    # Use the longest active profile to determine n_pulses for raw arrays.
-    # Export unique positions so MATLAB's reprocessing (interp1) won't fail.
-    wire_key = metadata.wire_name
-    if wire_key in raw_data:
-        wire_arr = np.asarray(raw_data[wire_key], dtype=np.float64)
-        # Deduplicate: keep only unique positions (sorted), averaging
-        # signal at duplicate positions — matches what Python analysis does.
-        unique_pos, inverse = np.unique(wire_arr, return_inverse=True)
-        data["wireData"] = unique_pos.reshape(1, -1)
-        data["wireMask"] = np.ones_like(data["wireData"], dtype=np.bool_)
-    else:
-        unique_pos = np.zeros(0, dtype=np.float64)
-        inverse = np.array([], dtype=int)
-        data["wireData"] = np.zeros((1, 0), dtype=np.float64)
-        data["wireMask"] = np.zeros((1, 0), dtype=np.bool_)
-
-    n_pulses = data["wireData"].shape[1]
-
-    if pmt_keys_ordered:
-        pmt_arrays = []
-        for key in pmt_keys_ordered:
-            collected_key = base_to_collected.get(key)
-            if collected_key:
-                arr = np.asarray(
-                    raw_data.get(collected_key, np.zeros(len(inverse))),
-                    dtype=np.float64,
-                ).ravel()
-                if len(inverse) > 0 and len(arr) == len(inverse):
-                    deduped = np.zeros(n_pulses, dtype=np.float64)
-                    counts = np.zeros(n_pulses, dtype=np.float64)
-                    np.add.at(deduped, inverse, arr)
-                    np.add.at(counts, inverse, 1.0)
-                    counts[counts == 0] = 1.0
-                    pmt_arrays.append(deduped / counts)
-                else:
-                    pmt_arrays.append(
-                        arr[:n_pulses] if len(arr) >= n_pulses else np.zeros(n_pulses)
-                    )
-            else:
-                pmt_arrays.append(np.zeros(n_pulses, dtype=np.float64))
-        data["PMTData"] = np.array(pmt_arrays).reshape(len(pmt_keys_ordered), n_pulses)
-    else:
-        data["PMTData"] = np.zeros((1, n_pulses), dtype=np.float64)
-
-    def _dedup_array(arr_raw, inv, n_out):
-        """Average raw array values at duplicate wire positions."""
-        if len(inv) > 0 and len(arr_raw) == len(inv):
-            deduped = np.zeros(n_out, dtype=np.float64)
-            counts = np.zeros(n_out, dtype=np.float64)
-            np.add.at(deduped, inv, arr_raw)
-            np.add.at(counts, inv, 1.0)
-            counts[counts == 0] = 1.0
-            return deduped / counts
-        return arr_raw[:n_out] if len(arr_raw) >= n_out else np.zeros(n_out)
-
-    if bpm_keys:
-        bpmx_arrays = []
-        bpmy_arrays = []
-        for key in bpm_keys:
-            bpm_val = raw_data.get(key, {})
-            if isinstance(bpm_val, dict):
-                raw_x = np.asarray(
-                    bpm_val.get("x", np.zeros(len(inverse))), dtype=np.float64
-                ).ravel()
-                raw_y = np.asarray(
-                    bpm_val.get("y", np.zeros(len(inverse))), dtype=np.float64
-                ).ravel()
-                bpmx_arrays.append(_dedup_array(raw_x, inverse, n_pulses))
-                bpmy_arrays.append(_dedup_array(raw_y, inverse, n_pulses))
-            else:
-                bpmx_arrays.append(np.zeros(n_pulses, dtype=np.float64))
-                bpmy_arrays.append(np.zeros(n_pulses, dtype=np.float64))
-        data["BPMXData"] = np.array(bpmx_arrays).reshape(len(bpm_keys), n_pulses)
-        data["BPMYData"] = np.array(bpmy_arrays).reshape(len(bpm_keys), n_pulses)
-    else:
-        data["BPMXData"] = np.zeros((0, n_pulses), dtype=np.float64)
-        data["BPMYData"] = np.zeros((0, n_pulses), dtype=np.float64)
-
-    if toro_keys:
-        toro_arrays = []
-        for key in toro_keys:
-            raw_t = np.asarray(
-                raw_data.get(key, np.zeros(len(inverse))), dtype=np.float64
-            ).ravel()
-            toro_arrays.append(_dedup_array(raw_t, inverse, n_pulses))
-        data["toroData"] = np.array(toro_arrays).reshape(len(toro_keys), n_pulses)
-    else:
-        # GUI always expects at least one toroid row
-        area = metadata.area or "LI21"
-        toro_keys = [f"TORO:{area}:1"]
-        data["toroList"] = np.array(toro_keys, dtype=object)
-        data["toroData"] = np.ones((1, n_pulses), dtype=np.float64) * 1e9
-
-    data["selectToro"] = np.float64(1.0)
-    data["selectBPM"] = (
-        np.ones((1, len(bpm_keys)), dtype=np.float64)
-        if bpm_keys
-        else np.zeros((1, 0), dtype=np.float64)
-    )
-
-    # --- R-matrices (optional) ---
-    if include_rmat and bpm_keys:
-        try:
-            data["rMatList"] = _fetch_rmat(
-                metadata.wire_name, bpm_keys, metadata.beampath, physics_model
-            )
-        except Exception:
-            data["rMatList"] = np.zeros((4, 6, len(bpm_keys)), dtype=np.float64)
-    else:
-        n_bpm = len(bpm_keys)
-        data["rMatList"] = (
-            np.zeros((4, 6, n_bpm), dtype=np.float64)
-            if n_bpm
-            else np.zeros((4, 6, 0), dtype=np.float64)
-        )
-
-    # --- Calibrated profiles (pos / signal) ---
-    default_det = metadata.default_detector
-    pos = {}
-    signal = {}
-    for tag in ("x", "y", "u"):
-        if tag in result.profiles and default_det:
-            prof = result.profiles[tag]
-            positions_beam = stage_to_beam(prof.positions, tag, metadata.install_angle)
-            pos[tag] = positions_beam.astype(np.float64)
-            det_data = prof.detectors.get(default_det)
-            signal[tag] = (
-                det_data.values.astype(np.float64)
-                if det_data is not None
-                else np.zeros_like(positions_beam)
-            )
-        else:
-            pos[tag] = np.zeros(0, dtype=np.float64)
-            signal[tag] = np.zeros(0, dtype=np.float64)
-
-    data["pos"] = pos
-    data["signal"] = signal
-
-    if default_det and pmt_keys_ordered:
-        default_det_base = (
-            default_det.rsplit(":", 1)[0] if full_pmt_keys else default_det
-        )
-        try:
-            data["selectPMT"] = np.float64(pmt_keys_ordered.index(default_det_base) + 1)
-        except ValueError:
-            data["selectPMT"] = np.float64(1.0)
-    else:
-        data["selectPMT"] = np.float64(1.0)
-
-    # --- Beam struct (fit results) ---
-    data["beam"] = _build_beam_struct(result, pos, signal)
-
-    # --- beamPV ---
-    data["beamPV"] = _build_beam_pv(wire_epics, data["beam"])
-
-    scipy.io.savemat(filepath, {"data": data}, do_compression=True, oned_as="row")
-    return filepath
+# ---------------------------------------------------------------------------
+# Device classification and resolution
+# ---------------------------------------------------------------------------
 
 
 def _classify_raw_data_keys(
@@ -476,12 +225,174 @@ def _classify_raw_data_keys(
         elif isinstance(raw_data[key], dict) and "x" in raw_data[key]:
             bpm_keys.append(key)
 
-    # Ensure pmt_keys matches detector order from metadata
     if metadata.detectors:
-        ordered_pmt = [d for d in metadata.detectors if d in set(pmt_keys)]
-        pmt_keys = ordered_pmt
+        pmt_keys = [d for d in metadata.detectors if d in set(pmt_keys)]
 
     return pmt_keys, bpm_keys, toro_keys
+
+
+def _resolve_devices(
+    metadata: Any, raw_data: dict, name_map: dict[str, str]
+) -> tuple[list[str], dict[str, str], list[str], list[str], bool]:
+    """Resolve device lists and align PMT ordering with the MATLAB config.
+
+    Returns (pmt_keys_ordered, base_to_collected, bpm_keys, toro_keys, has_sector_config).
+    """
+    pmt_keys, bpm_keys, toro_keys = _classify_raw_data_keys(raw_data, metadata)
+
+    base_to_collected = {k.rsplit(":", 1)[0]: k for k in pmt_keys}
+
+    cfg = _load_wirescan_config()
+    sector = _wire_to_sector(metadata.wire_name, cfg) or metadata.area
+    full_pmt_keys = _get_sector_pmt_list(sector, cfg)
+
+    if full_pmt_keys:
+        pmt_keys_ordered = full_pmt_keys
+        unmapped = [k for k in full_pmt_keys if k not in name_map]
+        if unmapped:
+            name_map.update(_build_name_map(unmapped))
+    else:
+        pmt_keys_ordered = pmt_keys
+        base_to_collected = {k: k for k in pmt_keys}
+
+    return pmt_keys_ordered, base_to_collected, bpm_keys, toro_keys, bool(full_pmt_keys)
+
+
+# ---------------------------------------------------------------------------
+# Raw data array builders
+# ---------------------------------------------------------------------------
+
+
+def _build_wire_data(
+    raw_data: dict, wire_key: str
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, int]:
+    """Deduplicate wire positions. Returns (wireData, wireMask, inverse, n_pulses)."""
+    if wire_key in raw_data:
+        wire_arr = np.asarray(raw_data[wire_key], dtype=np.float64)
+        unique_pos, inverse = np.unique(wire_arr, return_inverse=True)
+        wire_data = unique_pos.reshape(1, -1)
+        wire_mask = np.ones_like(wire_data, dtype=np.bool_)
+    else:
+        inverse = np.array([], dtype=int)
+        wire_data = np.zeros((1, 0), dtype=np.float64)
+        wire_mask = np.zeros((1, 0), dtype=np.bool_)
+
+    return wire_data, wire_mask, inverse, wire_data.shape[1]
+
+
+def _build_pmt_data(
+    raw_data: dict,
+    pmt_keys_ordered: list[str],
+    base_to_collected: dict[str, str],
+    inverse: np.ndarray,
+    n_pulses: int,
+) -> np.ndarray:
+    """Build PMTData array aligned to sector config order."""
+    if not pmt_keys_ordered:
+        return np.zeros((1, n_pulses), dtype=np.float64)
+
+    rows = []
+    for key in pmt_keys_ordered:
+        collected_key = base_to_collected.get(key)
+        if collected_key:
+            arr = np.asarray(
+                raw_data.get(collected_key, np.zeros(len(inverse))), dtype=np.float64
+            ).ravel()
+            rows.append(_dedup_array(arr, inverse, n_pulses))
+        else:
+            rows.append(np.zeros(n_pulses, dtype=np.float64))
+
+    return np.array(rows).reshape(len(pmt_keys_ordered), n_pulses)
+
+
+def _build_bpm_data(
+    raw_data: dict,
+    bpm_keys: list[str],
+    inverse: np.ndarray,
+    n_pulses: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Build BPMXData and BPMYData arrays."""
+    if not bpm_keys:
+        return (
+            np.zeros((0, n_pulses), dtype=np.float64),
+            np.zeros((0, n_pulses), dtype=np.float64),
+        )
+
+    x_rows, y_rows = [], []
+    for key in bpm_keys:
+        bpm_val = raw_data.get(key, {})
+        if isinstance(bpm_val, dict):
+            raw_x = np.asarray(
+                bpm_val.get("x", np.zeros(len(inverse))), dtype=np.float64
+            ).ravel()
+            raw_y = np.asarray(
+                bpm_val.get("y", np.zeros(len(inverse))), dtype=np.float64
+            ).ravel()
+            x_rows.append(_dedup_array(raw_x, inverse, n_pulses))
+            y_rows.append(_dedup_array(raw_y, inverse, n_pulses))
+        else:
+            x_rows.append(np.zeros(n_pulses, dtype=np.float64))
+            y_rows.append(np.zeros(n_pulses, dtype=np.float64))
+
+    return (
+        np.array(x_rows).reshape(len(bpm_keys), n_pulses),
+        np.array(y_rows).reshape(len(bpm_keys), n_pulses),
+    )
+
+
+def _build_toro_data(
+    raw_data: dict,
+    toro_keys: list[str],
+    inverse: np.ndarray,
+    n_pulses: int,
+    area: str,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Build toroData and toroList. Returns (toroData, toroList)."""
+    if toro_keys:
+        rows = []
+        for key in toro_keys:
+            raw_t = np.asarray(
+                raw_data.get(key, np.zeros(len(inverse))), dtype=np.float64
+            ).ravel()
+            rows.append(_dedup_array(raw_t, inverse, n_pulses))
+        return np.array(rows).reshape(len(toro_keys), n_pulses), None
+
+    # GUI always expects at least one toroid row
+    fallback_name = f"TORO:{area or 'LI21'}:1"
+    return np.ones((1, n_pulses), dtype=np.float64) * 1e9, np.array(
+        [fallback_name], dtype=object
+    )
+
+
+# ---------------------------------------------------------------------------
+# Profile and beam struct builders
+# ---------------------------------------------------------------------------
+
+
+def _build_profiles(
+    result: WireMeasurementAnalysisResult, metadata: Any
+) -> tuple[dict[str, np.ndarray], dict[str, np.ndarray]]:
+    """Build calibrated pos/signal dicts from analysis profiles."""
+    from slac_measurements.wires.analysis.coordinates import stage_to_beam
+
+    default_det = metadata.default_detector
+    pos = {}
+    signal = {}
+    for tag in ("x", "y", "u"):
+        if tag in result.profiles and default_det:
+            prof = result.profiles[tag]
+            positions_beam = stage_to_beam(prof.positions, tag, metadata.install_angle)
+            pos[tag] = positions_beam.astype(np.float64)
+            det_data = prof.detectors.get(default_det)
+            signal[tag] = (
+                det_data.values.astype(np.float64)
+                if det_data is not None
+                else np.zeros_like(positions_beam)
+            )
+        else:
+            pos[tag] = np.zeros(0, dtype=np.float64)
+            signal[tag] = np.zeros(0, dtype=np.float64)
+    return pos, signal
 
 
 def _build_beam_struct(
@@ -489,20 +400,12 @@ def _build_beam_struct(
     pos: dict[str, np.ndarray],
     signal: dict[str, np.ndarray],
 ) -> np.ndarray:
-    """Build MATLAB-compatible beam struct array.
-
-    Returns a numpy object array of shape (1, 1) containing a dict,
-    which scipy.io.savemat renders as a 1x1 struct array.
-    """
+    """Build MATLAB-compatible beam struct array (1x1 object array)."""
     from slac_measurements.wires.analysis.coordinates import stage_to_beam
 
     metadata = result.collection_result.metadata
     default_det = metadata.default_detector
     fit_result = result.fit_result
-
-    method_name = result.fitting_method.capitalize()
-    if method_name == "Gaussian":
-        method_name = "Gaussian"
 
     stats = np.zeros(6, dtype=np.float64)
     x_stat = np.zeros(5, dtype=np.float64)
@@ -522,7 +425,6 @@ def _build_beam_struct(
                 stat_map[tag][1] = mean_beam
                 stat_map[tag][2] = det_fit.sigma
 
-    # XY correlation from u-plane if available
     if "u" in fit_result and default_det:
         u_fit = fit_result["u"].detectors.get(default_det)
         if u_fit is not None:
@@ -535,7 +437,6 @@ def _build_beam_struct(
             )[0]
             stat_map["u"][2] = sigma_u
 
-    # SUM: integrate signal for each profile
     for tag in ("x", "y", "u"):
         if tag in result.profiles and default_det:
             det_data = result.profiles[tag].detectors.get(default_det)
@@ -547,9 +448,8 @@ def _build_beam_struct(
 
     stats[5] = stat_map["x"][0]
 
-    # Build prof arrays: [3 x N] = [positions; signal; fit_curve]
     beam_entry: dict[str, Any] = {
-        "method": method_name,
+        "method": result.fitting_method.capitalize(),
         "stats": stats.reshape(1, 6),
         "statsStd": np.zeros((1, 6), dtype=np.float64),
         "xStat": x_stat.reshape(1, 5),
@@ -574,7 +474,6 @@ def _build_beam_struct(
         else:
             beam_entry[prof_key] = np.zeros((3, 0), dtype=np.float64)
 
-    # scipy.io.savemat represents struct arrays as object arrays of dicts
     beam_array = np.empty((1, 1), dtype=object)
     beam_array[0, 0] = beam_entry
     return beam_array
@@ -637,3 +536,166 @@ def _fetch_rmat(
         if rmat_list
         else np.zeros((4, 6, 0), dtype=np.float64)
     )
+
+
+# ---------------------------------------------------------------------------
+# Main export function
+# ---------------------------------------------------------------------------
+
+
+def analysis_result_to_mat(
+    result: WireMeasurementAnalysisResult,
+    filepath: str,
+    *,
+    name_map: dict[str, str] | None = None,
+    include_rmat: bool = False,
+    physics_model: str = "BLEM",
+) -> str:
+    """Export a WireMeasurementAnalysisResult as a MATLAB .mat file.
+
+    The output file contains a single ``data`` struct variable matching
+    the layout produced by the MATLAB ``wirescan_gui`` ``dataSave``
+    function, so it can be loaded directly with ``File > Open``.
+
+    Parameters
+    ----------
+    result : WireMeasurementAnalysisResult
+        The analysis result to export.
+    filepath : str
+        Output ``.mat`` file path.
+    name_map : dict[str, str], optional
+        Mapping from MAD names to EPICS names.  If None, attempts auto-lookup
+        via ``slac_db``; falls back to using MAD names unchanged.
+    include_rmat : bool
+        Whether to fetch R-matrices from the optics model.  Default False.
+    physics_model : str
+        Model source for R-matrix retrieval.  Default ``"BLEM"``.
+
+    Returns
+    -------
+    str
+        Path to the saved ``.mat`` file.
+    """
+    metadata = result.collection_result.metadata
+    raw_data = result.collection_result.raw_data
+
+    if name_map is None:
+        name_map = _build_auto_name_map(metadata, raw_data)
+
+    def _epics(mad_name: str) -> str:
+        return name_map.get(mad_name, mad_name)
+
+    wire_epics = _epics(metadata.wire_name)
+
+    # --- Resolve device lists ---
+    pmt_ordered, base_map, bpm_keys, toro_keys, has_sector = _resolve_devices(
+        metadata, raw_data, name_map
+    )
+
+    # --- Wire positions (dedup) ---
+    wire_data, wire_mask, inverse, n_pulses = _build_wire_data(
+        raw_data, metadata.wire_name
+    )
+
+    # --- Raw signal arrays ---
+    pmt_data = _build_pmt_data(raw_data, pmt_ordered, base_map, inverse, n_pulses)
+    bpmx_data, bpmy_data = _build_bpm_data(raw_data, bpm_keys, inverse, n_pulses)
+    toro_data, toro_fallback_list = _build_toro_data(
+        raw_data, toro_keys, inverse, n_pulses, metadata.area
+    )
+
+    # --- EPICS name lists ---
+    pmt_epics = [_epics(k) for k in pmt_ordered]
+    bpm_epics = [_epics(k) for k in bpm_keys]
+    toro_epics = [_epics(k) for k in toro_keys] if toro_keys else None
+
+    # --- R-matrices ---
+    n_bpm = len(bpm_keys)
+    if include_rmat and bpm_keys:
+        try:
+            rmat = _fetch_rmat(
+                metadata.wire_name, bpm_keys, metadata.beampath, physics_model
+            )
+        except Exception:
+            rmat = np.zeros((4, 6, n_bpm), dtype=np.float64)
+    else:
+        rmat = np.zeros((4, 6, n_bpm), dtype=np.float64)
+
+    # --- Profiles ---
+    pos, signal = _build_profiles(result, metadata)
+
+    # --- selectPMT ---
+    default_det = metadata.default_detector
+    if default_det and pmt_ordered:
+        det_base = default_det.rsplit(":", 1)[0] if has_sector else default_det
+        try:
+            select_pmt = np.float64(pmt_ordered.index(det_base) + 1)
+        except ValueError:
+            select_pmt = np.float64(1.0)
+    else:
+        select_pmt = np.float64(1.0)
+
+    # --- Assemble data struct ---
+    data: dict[str, Any] = {
+        "name": wire_epics,
+        "wireName": wire_epics,
+        "wireMode": "wire",
+        "beampath": metadata.beampath or "",
+        "status": np.bool_(True),
+        "ts": (
+            datetime_to_matlab_datenum(metadata.timestamp)
+            if metadata.timestamp is not None
+            else np.float64(0.0)
+        ),
+        "wireAngle": np.float64(metadata.install_angle),
+        "wireScanDir": np.float64(0.0),
+        "wireDir": {
+            t: np.bool_(t in metadata.active_profiles) for t in ("x", "y", "u")
+        },
+        "wireLimit": {
+            t: (
+                np.array(metadata.scan_ranges[t], dtype=np.float64)
+                if t in metadata.scan_ranges
+                else np.array([0.0, 0.0], dtype=np.float64)
+            )
+            for t in ("x", "y", "u")
+        },
+        "wireCenter": {t: np.float64(0.0) for t in ("x", "y", "u")},
+        "wireSize": {t: np.float64(12.5) for t in ("x", "y", "u")},
+        "PMTList": np.array(pmt_epics, dtype=object)
+        if pmt_epics
+        else np.array([], dtype=object),
+        "BPMList": np.array(bpm_epics, dtype=object)
+        if bpm_epics
+        else np.array([], dtype=object),
+        "toroList": (
+            toro_fallback_list
+            if toro_fallback_list is not None
+            else (
+                np.array(toro_epics, dtype=object)
+                if toro_epics
+                else np.array([], dtype=object)
+            )
+        ),
+        "wireData": wire_data,
+        "wireMask": wire_mask,
+        "PMTData": pmt_data,
+        "BPMXData": bpmx_data,
+        "BPMYData": bpmy_data,
+        "toroData": toro_data,
+        "selectToro": np.float64(1.0),
+        "selectBPM": (
+            np.ones((1, n_bpm), dtype=np.float64)
+            if n_bpm
+            else np.zeros((1, 0), dtype=np.float64)
+        ),
+        "rMatList": rmat,
+        "pos": pos,
+        "signal": signal,
+        "selectPMT": select_pmt,
+        "beam": _build_beam_struct(result, pos, signal),
+    }
+    data["beamPV"] = _build_beam_pv(wire_epics, data["beam"])
+
+    scipy.io.savemat(filepath, {"data": data}, do_compression=True, oned_as="row")
+    return filepath

--- a/slac_measurements/wires/analysis/mat_export.py
+++ b/slac_measurements/wires/analysis/mat_export.py
@@ -98,12 +98,11 @@ def _build_name_map(mad_names: list[str]) -> dict[str, str]:
     return name_map
 
 
-def _get_sector_pmt_list(area: str) -> list[str]:
-    """Get the full PMT/detector list for a sector from wirescan_config.json."""
-    import pathlib
-
-    # Try wirescan_config.json (authoritative for the MATLAB GUI dropdown)
+def _load_wirescan_config() -> dict | None:
+    """Load wirescan_config.json from known locations."""
+    import json
     import os
+    import pathlib
 
     config_locations = [
         pathlib.Path("/usr/local/lcls/tools/matlab/toolbox/wirescan_config.json"),
@@ -113,17 +112,38 @@ def _get_sector_pmt_list(area: str) -> list[str]:
     for config_path in config_locations:
         if config_path.exists():
             try:
-                import json
-
                 with open(config_path) as f:
-                    cfg = json.load(f)
-                sectors = cfg.get("sectors", {})
-                if isinstance(sectors, dict) and area in sectors:
-                    pmt_list = sectors[area].get("PMTMADList", [])
-                    if pmt_list:
-                        return pmt_list
+                    return json.load(f)
             except Exception:
                 continue
+    return None
+
+
+def _wire_to_sector(wire_mad: str, cfg: dict | None) -> str | None:
+    """Look up which MATLAB GUI sector a wire belongs to."""
+    if cfg is None:
+        return None
+    sectors = cfg.get("sectors", {})
+    for sector_name, sector_data in sectors.items():
+        if not isinstance(sector_data, dict):
+            continue
+        wire_list = sector_data.get("wireMADList", [])
+        if wire_mad in wire_list:
+            return sector_name
+    return None
+
+
+def _get_sector_pmt_list(area: str, cfg: dict | None = None) -> list[str]:
+    """Get the full PMT/detector list for a sector from wirescan_config.json."""
+    if cfg is None:
+        cfg = _load_wirescan_config()
+
+    if cfg is not None:
+        sectors = cfg.get("sectors", {})
+        if isinstance(sectors, dict) and area in sectors:
+            pmt_list = sectors[area].get("PMTMADList", [])
+            if pmt_list:
+                return pmt_list
 
     # Fallback: wire_area_metadata.yaml from slac_db
     try:
@@ -245,12 +265,11 @@ def analysis_result_to_mat(
     # lookup from base MAD name → collected (suffixed) name for matching.
     base_to_collected = {k.rsplit(":", 1)[0]: k for k in pmt_keys}
     # metadata.area comes from the device DB (e.g. "L3") which doesn't match
-    # the MATLAB GUI sector names (e.g. "LI28").  Derive sector from the wire
-    # EPICS name (WIRE:LI28:744 → LI28) which always matches the config keys.
-    sector = wire_epics.split(":")[1] if ":" in wire_epics else metadata.area
-    full_pmt_keys = _get_sector_pmt_list(sector)
-    if not full_pmt_keys:
-        full_pmt_keys = _get_sector_pmt_list(metadata.area)
+    # the MATLAB GUI sector names (e.g. "LI28").  Look up the wire's sector
+    # from the config's wireMADList (handles e.g. WS27644 → LI28).
+    cfg = _load_wirescan_config()
+    sector = _wire_to_sector(metadata.wire_name, cfg) or metadata.area
+    full_pmt_keys = _get_sector_pmt_list(sector, cfg)
     if full_pmt_keys:
         pmt_keys_ordered = full_pmt_keys
         # Ensure name_map covers config-only detectors (e.g. PMT28750)

--- a/slac_measurements/wires/analysis/mat_export.py
+++ b/slac_measurements/wires/analysis/mat_export.py
@@ -469,31 +469,6 @@ def _build_beam_pv(wire_name: str, beam: np.ndarray) -> np.ndarray:
     return pv_array
 
 
-def _fetch_rmat(
-    wire_name: str,
-    bpm_keys: list[str],
-    beampath: str | None,
-    physics_model: str,
-) -> np.ndarray:
-    """Fetch R-matrices from the optics model (requires network)."""
-    from lcls_tools.common.devices.reader import create_wire
-
-    device = create_wire(wire_name)
-    rmat_list = []
-    for bpm in bpm_keys:
-        try:
-            rmat = device.get_rmat(bpm, model=physics_model)
-            rmat_list.append(rmat[:4, :6])
-        except Exception:
-            rmat_list.append(np.zeros((4, 6), dtype=np.float64))
-
-    return (
-        np.stack(rmat_list, axis=2)
-        if rmat_list
-        else np.zeros((4, 6, 0), dtype=np.float64)
-    )
-
-
 # ---------------------------------------------------------------------------
 # Main export function
 # ---------------------------------------------------------------------------
@@ -504,8 +479,6 @@ def analysis_result_to_mat(
     filepath: str,
     *,
     name_map: dict[str, str] | None = None,
-    include_rmat: bool = False,
-    physics_model: str = "BLEM",
 ) -> str:
     """Export a WireMeasurementAnalysisResult as a MATLAB .mat file.
 
@@ -522,10 +495,6 @@ def analysis_result_to_mat(
     name_map : dict[str, str], optional
         Mapping from MAD names to EPICS names.  If None, attempts auto-lookup
         via ``slac_db``; falls back to using MAD names unchanged.
-    include_rmat : bool
-        Whether to fetch R-matrices from the optics model.  Default False.
-    physics_model : str
-        Model source for R-matrix retrieval.  Default ``"BLEM"``.
 
     Returns
     -------
@@ -563,17 +532,7 @@ def analysis_result_to_mat(
     bpm_epics = [_epics(k) for k in bpm_keys]
     toro_epics = [_epics(k) for k in toro_keys] if toro_keys else None
 
-    # --- R-matrices ---
     n_bpm = len(bpm_keys)
-    if include_rmat and bpm_keys:
-        try:
-            rmat = _fetch_rmat(
-                metadata.wire_name, bpm_keys, metadata.beampath, physics_model
-            )
-        except Exception:
-            rmat = np.zeros((4, 6, n_bpm), dtype=np.float64)
-    else:
-        rmat = np.zeros((4, 6, n_bpm), dtype=np.float64)
 
     # --- Profiles ---
     pos, signal = _build_profiles(result, metadata)
@@ -643,7 +602,7 @@ def analysis_result_to_mat(
             if n_bpm
             else np.zeros((1, 0), dtype=np.float64)
         ),
-        "rMatList": rmat,
+        "rMatList": np.zeros((4, 6, n_bpm), dtype=np.float64),
         "pos": pos,
         "signal": signal,
         "selectPMT": select_pmt,

--- a/slac_measurements/wires/analysis/mat_export.py
+++ b/slac_measurements/wires/analysis/mat_export.py
@@ -190,6 +190,9 @@ def analysis_result_to_mat(
         if metadata.detectors:
             all_mad_names.extend(metadata.detectors)
         all_mad_names.extend(k for k in raw_data.keys() if k != metadata.wire_name)
+        # Also include base MAD names (strip beampath suffix) for lookup
+        base_names = {n.rsplit(":", 1)[0] for n in all_mad_names}
+        all_mad_names = list(set(all_mad_names) | base_names)
         name_map = _build_name_map(all_mad_names)
 
     def _epics(mad_name: str) -> str:
@@ -237,14 +240,16 @@ def analysis_result_to_mat(
     pmt_keys, bpm_keys, toro_keys = _classify_raw_data_keys(raw_data, metadata)
 
     # Get the full sector PMT list so indices match the GUI dropdown.
+    # Python detector names carry a beampath suffix (e.g. "PMT29150:LI29")
+    # while the config uses short MAD names (e.g. "PMT29150").  Build a
+    # lookup from base MAD name → collected (suffixed) name for matching.
+    base_to_collected = {k.rsplit(":", 1)[0]: k for k in pmt_keys}
     full_pmt_keys = _get_sector_pmt_list(metadata.area)
     if full_pmt_keys:
-        # Reorder pmt_keys to match sector order, pad missing with None
-        collected_set = set(pmt_keys)
         pmt_keys_ordered = full_pmt_keys
     else:
         pmt_keys_ordered = pmt_keys
-        collected_set = set(pmt_keys)
+        base_to_collected = {k: k for k in pmt_keys}
 
     pmt_epics = [_epics(k) for k in pmt_keys_ordered]
     bpm_epics = [_epics(k) for k in bpm_keys]
@@ -281,9 +286,11 @@ def analysis_result_to_mat(
     if pmt_keys_ordered:
         pmt_arrays = []
         for key in pmt_keys_ordered:
-            if key in collected_set:
+            collected_key = base_to_collected.get(key)
+            if collected_key:
                 arr = np.asarray(
-                    raw_data.get(key, np.zeros(len(inverse))), dtype=np.float64
+                    raw_data.get(collected_key, np.zeros(len(inverse))),
+                    dtype=np.float64,
                 ).ravel()
                 if len(inverse) > 0 and len(arr) == len(inverse):
                     deduped = np.zeros(n_pulses, dtype=np.float64)
@@ -397,8 +404,11 @@ def analysis_result_to_mat(
     data["signal"] = signal
 
     if default_det and pmt_keys_ordered:
+        default_det_base = (
+            default_det.rsplit(":", 1)[0] if full_pmt_keys else default_det
+        )
         try:
-            data["selectPMT"] = np.float64(pmt_keys_ordered.index(default_det) + 1)
+            data["selectPMT"] = np.float64(pmt_keys_ordered.index(default_det_base) + 1)
         except ValueError:
             data["selectPMT"] = np.float64(1.0)
     else:

--- a/slac_measurements/wires/analysis/mat_export.py
+++ b/slac_measurements/wires/analysis/mat_export.py
@@ -98,6 +98,26 @@ def _build_name_map(mad_names: list[str]) -> dict[str, str]:
     return name_map
 
 
+def _get_sector_pmt_list(area: str) -> list[str]:
+    """Get the full PMT/detector list for a sector from wire_area_metadata.yaml."""
+    try:
+        import slac_db.config
+
+        import yaml
+
+        meta_path = slac_db.config.package_data() / "wire_area_metadata.yaml"
+        if not meta_path.exists():
+            return []
+        with open(meta_path) as f:
+            area_meta = yaml.safe_load(f)
+        if area in area_meta and "detectors" in area_meta[area]:
+            # Format is "PMT29150:LI29" — take the MAD name before the colon
+            return [d.split(":")[0] for d in area_meta[area]["detectors"]]
+    except Exception:
+        pass
+    return []
+
+
 def analysis_result_to_mat(
     result: WireMeasurementAnalysisResult,
     filepath: str,
@@ -192,7 +212,17 @@ def analysis_result_to_mat(
     # --- Device lists and raw data ---
     pmt_keys, bpm_keys, toro_keys = _classify_raw_data_keys(raw_data, metadata)
 
-    pmt_epics = [_epics(k) for k in pmt_keys]
+    # Get the full sector PMT list so indices match the GUI dropdown.
+    full_pmt_keys = _get_sector_pmt_list(metadata.area)
+    if full_pmt_keys:
+        # Reorder pmt_keys to match sector order, pad missing with None
+        collected_set = set(pmt_keys)
+        pmt_keys_ordered = full_pmt_keys
+    else:
+        pmt_keys_ordered = pmt_keys
+        collected_set = set(pmt_keys)
+
+    pmt_epics = [_epics(k) for k in pmt_keys_ordered]
     bpm_epics = [_epics(k) for k in bpm_keys]
     toro_epics = [_epics(k) for k in toro_keys]
 
@@ -224,25 +254,27 @@ def analysis_result_to_mat(
 
     n_pulses = data["wireData"].shape[1]
 
-    if pmt_keys:
+    if pmt_keys_ordered:
         pmt_arrays = []
-        for key in pmt_keys:
-            arr = np.asarray(
-                raw_data.get(key, np.zeros(len(inverse))), dtype=np.float64
-            ).ravel()
-            if len(inverse) > 0 and len(arr) == len(inverse):
-                # Average signal at duplicate positions
-                deduped = np.zeros(n_pulses, dtype=np.float64)
-                counts = np.zeros(n_pulses, dtype=np.float64)
-                np.add.at(deduped, inverse, arr)
-                np.add.at(counts, inverse, 1.0)
-                counts[counts == 0] = 1.0
-                pmt_arrays.append(deduped / counts)
+        for key in pmt_keys_ordered:
+            if key in collected_set:
+                arr = np.asarray(
+                    raw_data.get(key, np.zeros(len(inverse))), dtype=np.float64
+                ).ravel()
+                if len(inverse) > 0 and len(arr) == len(inverse):
+                    deduped = np.zeros(n_pulses, dtype=np.float64)
+                    counts = np.zeros(n_pulses, dtype=np.float64)
+                    np.add.at(deduped, inverse, arr)
+                    np.add.at(counts, inverse, 1.0)
+                    counts[counts == 0] = 1.0
+                    pmt_arrays.append(deduped / counts)
+                else:
+                    pmt_arrays.append(
+                        arr[:n_pulses] if len(arr) >= n_pulses else np.zeros(n_pulses)
+                    )
             else:
-                pmt_arrays.append(
-                    arr[:n_pulses] if len(arr) >= n_pulses else np.zeros(n_pulses)
-                )
-        data["PMTData"] = np.array(pmt_arrays).reshape(len(pmt_keys), n_pulses)
+                pmt_arrays.append(np.zeros(n_pulses, dtype=np.float64))
+        data["PMTData"] = np.array(pmt_arrays).reshape(len(pmt_keys_ordered), n_pulses)
     else:
         data["PMTData"] = np.zeros((1, n_pulses), dtype=np.float64)
 
@@ -340,9 +372,9 @@ def analysis_result_to_mat(
     data["pos"] = pos
     data["signal"] = signal
 
-    if default_det and metadata.detectors:
+    if default_det and pmt_keys_ordered:
         try:
-            data["selectPMT"] = np.float64(metadata.detectors.index(default_det) + 1)
+            data["selectPMT"] = np.float64(pmt_keys_ordered.index(default_det) + 1)
         except ValueError:
             data["selectPMT"] = np.float64(1.0)
     else:

--- a/slac_measurements/wires/analysis/mat_export.py
+++ b/slac_measurements/wires/analysis/mat_export.py
@@ -5,11 +5,25 @@ Produces files compatible with the MATLAB wirescan_gui (File > Open).
 
 from __future__ import annotations
 
+import json
+import os
+import pathlib
+import warnings
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import scipy.io
+import yaml
+
+try:
+    import slac_db.config
+
+    _SLAC_DB_YAML: str | None = slac_db.config.yaml()
+    _SLAC_DB_PACKAGE_DATA: pathlib.Path | None = slac_db.config.package_data()
+except (ImportError, Exception):
+    _SLAC_DB_YAML = None
+    _SLAC_DB_PACKAGE_DATA = None
 
 if TYPE_CHECKING:
     from slac_measurements.wires.analysis.results import (
@@ -50,13 +64,7 @@ def _dedup_array(raw: np.ndarray, inverse: np.ndarray, n_out: int) -> np.ndarray
 
 def _build_name_map(mad_names: list[str]) -> dict[str, str]:
     """Build MAD→EPICS name map from slac_db YAML device configs."""
-    import warnings
-
-    try:
-        import slac_db.config
-
-        yaml_dir = slac_db.config.yaml()
-    except (ImportError, Exception):
+    if _SLAC_DB_YAML is None:
         warnings.warn(
             "slac_db not available; MAD names will not be converted to EPICS. "
             "Pass name_map explicitly to to_mat().",
@@ -64,14 +72,10 @@ def _build_name_map(mad_names: list[str]) -> dict[str, str]:
         )
         return {}
 
-    import pathlib
-
-    import yaml
-
     mad_set = set(mad_names)
     name_map: dict[str, str] = {}
 
-    yaml_path = pathlib.Path(yaml_dir)
+    yaml_path = pathlib.Path(_SLAC_DB_YAML)
     if not yaml_path.is_dir():
         warnings.warn(
             f"slac_db YAML directory not found: {yaml_path}. "
@@ -137,10 +141,6 @@ def _build_auto_name_map(metadata: Any, raw_data: dict) -> dict[str, str]:
 
 def _load_wirescan_config() -> dict | None:
     """Load wirescan_config.json from known locations."""
-    import json
-    import os
-    import pathlib
-
     config_locations = [
         pathlib.Path("/usr/local/lcls/tools/matlab/toolbox/wirescan_config.json"),
         pathlib.Path(os.environ.get("MATLABPATH", "")) / "wirescan_config.json",
@@ -181,19 +181,13 @@ def _get_sector_pmt_list(area: str, cfg: dict | None = None) -> list[str]:
             if pmt_list:
                 return pmt_list
 
-    try:
-        import slac_db.config
-
-        import yaml
-
-        meta_path = slac_db.config.package_data() / "wire_area_metadata.yaml"
+    if _SLAC_DB_PACKAGE_DATA is not None:
+        meta_path = _SLAC_DB_PACKAGE_DATA / "wire_area_metadata.yaml"
         if meta_path.exists():
             with open(meta_path) as f:
                 area_meta = yaml.safe_load(f)
             if area in area_meta and "detectors" in area_meta[area]:
                 return [d.split(":")[0] for d in area_meta[area]["detectors"]]
-    except Exception:
-        pass
     return []
 
 

--- a/slac_measurements/wires/analysis/mat_export.py
+++ b/slac_measurements/wires/analysis/mat_export.py
@@ -244,7 +244,13 @@ def analysis_result_to_mat(
     # while the config uses short MAD names (e.g. "PMT29150").  Build a
     # lookup from base MAD name → collected (suffixed) name for matching.
     base_to_collected = {k.rsplit(":", 1)[0]: k for k in pmt_keys}
-    full_pmt_keys = _get_sector_pmt_list(metadata.area)
+    # metadata.area comes from the device DB (e.g. "L3") which doesn't match
+    # the MATLAB GUI sector names (e.g. "LI28").  Derive sector from the wire
+    # EPICS name (WIRE:LI28:744 → LI28) which always matches the config keys.
+    sector = wire_epics.split(":")[1] if ":" in wire_epics else metadata.area
+    full_pmt_keys = _get_sector_pmt_list(sector)
+    if not full_pmt_keys:
+        full_pmt_keys = _get_sector_pmt_list(metadata.area)
     if full_pmt_keys:
         pmt_keys_ordered = full_pmt_keys
         # Ensure name_map covers config-only detectors (e.g. PMT28750)

--- a/slac_measurements/wires/analysis/mat_export.py
+++ b/slac_measurements/wires/analysis/mat_export.py
@@ -482,18 +482,23 @@ def _fetch_rmat_list(
 
     try:
         from meme.model import Model
-    except ImportError:
-        return np.zeros((4, 6, n_bpm), dtype=np.float64)
 
-    model = Model(beampath, model_source="BLEM", use_design=False)
-    slabs = []
-    for bpm in bpm_keys:
-        try:
-            rmat = model.get_rmat(from_device=wire_name, to_device=bpm)
-            slabs.append(rmat[:4, :6].astype(np.float64))
-        except Exception:
-            slabs.append(np.zeros((4, 6), dtype=np.float64))
-    return np.stack(slabs, axis=2)
+        model = Model(beampath, model_source="BLEM", use_design=False)
+        slabs = []
+        for bpm in bpm_keys:
+            try:
+                rmat = model.get_rmat(from_device=wire_name, to_device=bpm)
+                slabs.append(rmat[:4, :6].astype(np.float64))
+            except Exception:
+                slabs.append(np.zeros((4, 6), dtype=np.float64))
+        return np.stack(slabs, axis=2)
+    except Exception:
+        warnings.warn(
+            "Could not fetch R-matrices from model; jitter correction "
+            "will not work in the MATLAB GUI for this file.",
+            stacklevel=2,
+        )
+        return np.zeros((4, 6, n_bpm), dtype=np.float64)
 
 
 # ---------------------------------------------------------------------------

--- a/slac_measurements/wires/analysis/mat_export.py
+++ b/slac_measurements/wires/analysis/mat_export.py
@@ -40,18 +40,6 @@ def datetime_to_matlab_datenum(dt: datetime) -> float:
     return MATLAB_EPOCH_OFFSET + (dt - epoch).total_seconds() / 86400.0
 
 
-def _dedup_array(raw: np.ndarray, inverse: np.ndarray, n_out: int) -> np.ndarray:
-    """Average raw array values at duplicate wire positions."""
-    if len(inverse) > 0 and len(raw) == len(inverse):
-        deduped = np.zeros(n_out, dtype=np.float64)
-        counts = np.zeros(n_out, dtype=np.float64)
-        np.add.at(deduped, inverse, raw)
-        np.add.at(counts, inverse, 1.0)
-        counts[counts == 0] = 1.0
-        return deduped / counts
-    return raw[:n_out] if len(raw) >= n_out else np.zeros(n_out, dtype=np.float64)
-
-
 # ---------------------------------------------------------------------------
 # Name map (MAD → EPICS)
 # ---------------------------------------------------------------------------
@@ -239,26 +227,22 @@ def _resolve_devices(
 
 def _build_wire_data(
     raw_data: dict, wire_key: str
-) -> tuple[np.ndarray, np.ndarray, np.ndarray, int]:
-    """Deduplicate wire positions. Returns (wireData, wireMask, inverse, n_pulses)."""
+) -> tuple[np.ndarray, np.ndarray, int]:
+    """Extract wire positions. Returns (wireData, wireMask, n_pulses)."""
     if wire_key in raw_data:
-        wire_arr = np.asarray(raw_data[wire_key], dtype=np.float64)
-        unique_pos, inverse = np.unique(wire_arr, return_inverse=True)
-        wire_data = unique_pos.reshape(1, -1)
-        wire_mask = np.ones_like(wire_data, dtype=np.bool_)
+        wire_arr = np.asarray(raw_data[wire_key], dtype=np.float64).reshape(1, -1)
+        wire_mask = np.ones_like(wire_arr, dtype=np.bool_)
     else:
-        inverse = np.array([], dtype=int)
-        wire_data = np.zeros((1, 0), dtype=np.float64)
+        wire_arr = np.zeros((1, 0), dtype=np.float64)
         wire_mask = np.zeros((1, 0), dtype=np.bool_)
 
-    return wire_data, wire_mask, inverse, wire_data.shape[1]
+    return wire_arr, wire_mask, wire_arr.shape[1]
 
 
 def _build_pmt_data(
     raw_data: dict,
     pmt_keys_ordered: list[str],
     base_to_collected: dict[str, str],
-    inverse: np.ndarray,
     n_pulses: int,
 ) -> np.ndarray:
     """Build PMTData array aligned to sector config order."""
@@ -270,9 +254,9 @@ def _build_pmt_data(
         collected_key = base_to_collected.get(key)
         if collected_key:
             arr = np.asarray(
-                raw_data.get(collected_key, np.zeros(len(inverse))), dtype=np.float64
-            ).ravel()
-            rows.append(_dedup_array(arr, inverse, n_pulses))
+                raw_data.get(collected_key, np.zeros(n_pulses)), dtype=np.float64
+            ).ravel()[:n_pulses]
+            rows.append(arr)
         else:
             rows.append(np.zeros(n_pulses, dtype=np.float64))
 
@@ -282,7 +266,6 @@ def _build_pmt_data(
 def _build_bpm_data(
     raw_data: dict,
     bpm_keys: list[str],
-    inverse: np.ndarray,
     n_pulses: int,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Build BPMXData and BPMYData arrays."""
@@ -297,13 +280,13 @@ def _build_bpm_data(
         bpm_val = raw_data.get(key, {})
         if isinstance(bpm_val, dict):
             raw_x = np.asarray(
-                bpm_val.get("x", np.zeros(len(inverse))), dtype=np.float64
-            ).ravel()
+                bpm_val.get("x", np.zeros(n_pulses)), dtype=np.float64
+            ).ravel()[:n_pulses]
             raw_y = np.asarray(
-                bpm_val.get("y", np.zeros(len(inverse))), dtype=np.float64
-            ).ravel()
-            x_rows.append(_dedup_array(raw_x, inverse, n_pulses))
-            y_rows.append(_dedup_array(raw_y, inverse, n_pulses))
+                bpm_val.get("y", np.zeros(n_pulses)), dtype=np.float64
+            ).ravel()[:n_pulses]
+            x_rows.append(raw_x)
+            y_rows.append(raw_y)
         else:
             x_rows.append(np.zeros(n_pulses, dtype=np.float64))
             y_rows.append(np.zeros(n_pulses, dtype=np.float64))
@@ -317,7 +300,6 @@ def _build_bpm_data(
 def _build_toro_data(
     raw_data: dict,
     toro_keys: list[str],
-    inverse: np.ndarray,
     n_pulses: int,
     area: str,
 ) -> tuple[np.ndarray, np.ndarray]:
@@ -326,9 +308,9 @@ def _build_toro_data(
         rows = []
         for key in toro_keys:
             raw_t = np.asarray(
-                raw_data.get(key, np.zeros(len(inverse))), dtype=np.float64
-            ).ravel()
-            rows.append(_dedup_array(raw_t, inverse, n_pulses))
+                raw_data.get(key, np.zeros(n_pulses)), dtype=np.float64
+            ).ravel()[:n_pulses]
+            rows.append(raw_t)
         return np.array(rows).reshape(len(toro_keys), n_pulses), None
 
     # GUI always expects at least one toroid row
@@ -566,16 +548,14 @@ def analysis_result_to_mat(
         metadata, raw_data, name_map
     )
 
-    # --- Wire positions (dedup) ---
-    wire_data, wire_mask, inverse, n_pulses = _build_wire_data(
-        raw_data, metadata.wire_name
-    )
+    # --- Wire positions ---
+    wire_data, wire_mask, n_pulses = _build_wire_data(raw_data, metadata.wire_name)
 
     # --- Raw signal arrays ---
-    pmt_data = _build_pmt_data(raw_data, pmt_ordered, base_map, inverse, n_pulses)
-    bpmx_data, bpmy_data = _build_bpm_data(raw_data, bpm_keys, inverse, n_pulses)
+    pmt_data = _build_pmt_data(raw_data, pmt_ordered, base_map, n_pulses)
+    bpmx_data, bpmy_data = _build_bpm_data(raw_data, bpm_keys, n_pulses)
     toro_data, toro_fallback_list = _build_toro_data(
-        raw_data, toro_keys, inverse, n_pulses, metadata.area
+        raw_data, toro_keys, n_pulses, metadata.area
     )
 
     # --- EPICS name lists ---

--- a/slac_measurements/wires/analysis/results.py
+++ b/slac_measurements/wires/analysis/results.py
@@ -51,6 +51,12 @@ class WireMeasurementAnalysisResult(BeamProfileMeasurementResult):
     jitter_corrected: bool = False
     jitter_rms: tuple[float, float] | None = None
 
+    def to_mat(self, filepath: str, **kwargs) -> str:
+        """Export this result as a MATLAB .mat file compatible with wirescan_gui."""
+        from slac_measurements.wires.analysis.mat_export import analysis_result_to_mat
+
+        return analysis_result_to_mat(self, filepath, **kwargs)
+
     def reanalyze(
         self,
         jitter_correction: bool = False,

--- a/tests/test_mat_export.py
+++ b/tests/test_mat_export.py
@@ -1,0 +1,327 @@
+"""Tests for the MATLAB .mat export functionality."""
+
+import numpy as np
+import scipy.io
+from datetime import datetime, timezone
+from tempfile import NamedTemporaryFile
+from unittest import TestCase
+
+from slac_measurements.wires.analysis.mat_export import (
+    analysis_result_to_mat,
+    datetime_to_matlab_datenum,
+)
+from slac_measurements.wires.analysis.results import (
+    DetectorFit,
+    DetectorProfileMeasurement,
+    FitResult,
+    ProfileMeasurement,
+    WireMeasurementAnalysisResult,
+)
+from slac_measurements.wires.collection.results import (
+    MeasurementMetadata,
+    WireMeasurementCollectionResult,
+)
+
+
+def _make_analysis_result(
+    *,
+    active_profiles=("x", "y"),
+    include_bpms=True,
+) -> WireMeasurementAnalysisResult:
+    """Build a synthetic analysis result for testing."""
+    n_pulses = 50
+    positions_x = np.linspace(28000, 32000, n_pulses)
+    positions_y = np.linspace(15000, 19000, n_pulses)
+    signal_x = np.exp(-0.5 * ((positions_x - 30000) / 500) ** 2)
+    signal_y = np.exp(-0.5 * ((positions_y - 17000) / 300) ** 2)
+
+    raw_data = {
+        "WIRE:LI21:285": positions_x,
+        "PMT:LI21:100": signal_x * 1000,
+        "PMT:LI21:200": signal_x * 800,
+    }
+
+    if include_bpms:
+        raw_data["BPMS:LI21:301"] = {
+            "x": np.random.randn(n_pulses) * 0.1,
+            "y": np.random.randn(n_pulses) * 0.05,
+        }
+        raw_data["BPMS:LI21:401"] = {
+            "x": np.random.randn(n_pulses) * 0.12,
+            "y": np.random.randn(n_pulses) * 0.06,
+        }
+
+    scan_ranges = {"x": (28000, 32000)}
+    profiles_list = list(active_profiles)
+    if "y" in active_profiles:
+        scan_ranges["y"] = (15000, 19000)
+
+    metadata = MeasurementMetadata(
+        wire_name="WIRE:LI21:285",
+        area="LI21",
+        beampath="CU_HXR",
+        detectors=["PMT:LI21:100", "PMT:LI21:200"],
+        default_detector="PMT:LI21:100",
+        scan_ranges=scan_ranges,
+        timestamp=datetime(2025, 3, 15, 14, 30, 0, tzinfo=timezone.utc),
+        active_profiles=profiles_list,
+        install_angle=45.0,
+    )
+
+    collection_result = WireMeasurementCollectionResult(
+        raw_data=raw_data, metadata=metadata
+    )
+
+    fit_result = {}
+    profiles = {}
+
+    if "x" in active_profiles:
+        fit_result["x"] = FitResult(
+            detectors={
+                "PMT:LI21:100": DetectorFit(
+                    mean=30000.0,
+                    sigma=353.5,
+                    amplitude=1.0,
+                    offset=0.0,
+                    curve=signal_x,
+                    positions=positions_x * np.sin(np.radians(45.0)),
+                ),
+                "PMT:LI21:200": DetectorFit(
+                    mean=30000.0,
+                    sigma=360.0,
+                    amplitude=0.8,
+                    offset=0.0,
+                    curve=signal_x * 0.8,
+                    positions=positions_x * np.sin(np.radians(45.0)),
+                ),
+            }
+        )
+        profiles["x"] = ProfileMeasurement(
+            positions=positions_x,
+            profile_indices=np.arange(n_pulses),
+            detectors={
+                "PMT:LI21:100": DetectorProfileMeasurement(
+                    values=signal_x * 1000, units="counts", label="PMT:LI21:100"
+                ),
+                "PMT:LI21:200": DetectorProfileMeasurement(
+                    values=signal_x * 800, units="counts", label="PMT:LI21:200"
+                ),
+            },
+        )
+
+    if "y" in active_profiles:
+        fit_result["y"] = FitResult(
+            detectors={
+                "PMT:LI21:100": DetectorFit(
+                    mean=17000.0,
+                    sigma=212.1,
+                    amplitude=1.0,
+                    offset=0.0,
+                    curve=signal_y,
+                    positions=positions_y * np.cos(np.radians(45.0)),
+                ),
+            }
+        )
+        profiles["y"] = ProfileMeasurement(
+            positions=positions_y,
+            profile_indices=np.arange(n_pulses),
+            detectors={
+                "PMT:LI21:100": DetectorProfileMeasurement(
+                    values=signal_y * 1000, units="counts", label="PMT:LI21:100"
+                ),
+            },
+        )
+
+    return WireMeasurementAnalysisResult(
+        fit_result=fit_result,
+        collection_result=collection_result,
+        profiles=profiles,
+        rms_sizes=np.array([353.5, 212.1]),
+        metadata=metadata,
+    )
+
+
+class TestDatetimeToMatlabDatenum(TestCase):
+    def test_unix_epoch(self):
+        dt = datetime(1970, 1, 1, tzinfo=timezone.utc)
+        self.assertAlmostEqual(datetime_to_matlab_datenum(dt), 719529.0, places=6)
+
+    def test_known_date(self):
+        dt = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        expected = 739618.0
+        self.assertAlmostEqual(datetime_to_matlab_datenum(dt), expected, places=6)
+
+    def test_with_time(self):
+        dt = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        expected = 739618.5
+        self.assertAlmostEqual(datetime_to_matlab_datenum(dt), expected, places=6)
+
+    def test_naive_datetime_treated_as_utc(self):
+        dt_naive = datetime(2025, 1, 1, 0, 0, 0)
+        dt_utc = datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        self.assertAlmostEqual(
+            datetime_to_matlab_datenum(dt_naive),
+            datetime_to_matlab_datenum(dt_utc),
+            places=6,
+        )
+
+
+class TestAnalysisResultToMat(TestCase):
+    def setUp(self):
+        self.result = _make_analysis_result()
+
+    def _export_and_load(self, result=None, **kwargs):
+        if result is None:
+            result = self.result
+        with NamedTemporaryFile(suffix=".mat", delete=False) as f:
+            path = f.name
+        analysis_result_to_mat(result, path, **kwargs)
+        return scipy.io.loadmat(path, squeeze_me=False)
+
+    def _data(self, mat):
+        return mat["data"][0, 0]
+
+    def test_top_level_contains_data_struct(self):
+        mat = self._export_and_load()
+        self.assertIn("data", mat)
+
+    def test_scalar_string_fields(self):
+        mat = self._export_and_load()
+        data = self._data(mat)
+        self.assertEqual(str(data["name"][0]), "WIRE:LI21:285")
+        self.assertEqual(str(data["wireName"][0]), "WIRE:LI21:285")
+        self.assertEqual(str(data["wireMode"][0]), "wire")
+        self.assertEqual(str(data["beampath"][0]), "CU_HXR")
+
+    def test_timestamp_is_valid_datenum(self):
+        mat = self._export_and_load()
+        data = self._data(mat)
+        ts = float(data["ts"][0, 0])
+        self.assertGreater(ts, 700000)
+        self.assertLess(ts, 800000)
+
+    def test_wire_geometry_fields(self):
+        mat = self._export_and_load()
+        data = self._data(mat)
+        self.assertAlmostEqual(float(data["wireAngle"][0, 0]), 45.0)
+
+        wire_dir = data["wireDir"][0, 0]
+        self.assertTrue(bool(wire_dir["x"][0, 0]))
+        self.assertTrue(bool(wire_dir["y"][0, 0]))
+        self.assertFalse(bool(wire_dir["u"][0, 0]))
+
+    def test_wire_limit_shape(self):
+        mat = self._export_and_load()
+        data = self._data(mat)
+        wire_limit = data["wireLimit"][0, 0]
+        x_limit = wire_limit["x"].ravel()
+        self.assertEqual(len(x_limit), 2)
+        self.assertAlmostEqual(x_limit[0], 28000.0)
+        self.assertAlmostEqual(x_limit[1], 32000.0)
+
+    def test_device_lists(self):
+        mat = self._export_and_load()
+        data = self._data(mat)
+        pmt_list = data["PMTList"].ravel()
+        self.assertEqual(len(pmt_list), 2)
+        self.assertEqual(str(pmt_list[0][0]), "PMT:LI21:100")
+
+        bpm_list = data["BPMList"].ravel()
+        self.assertEqual(len(bpm_list), 2)
+
+    def test_raw_data_shapes(self):
+        mat = self._export_and_load()
+        data = self._data(mat)
+        wire_data = np.asarray(data["wireData"])
+        self.assertEqual(wire_data.ndim, 3)
+        self.assertEqual(wire_data.shape[0], 1)
+        self.assertEqual(wire_data.shape[2], 1)
+        self.assertEqual(wire_data.shape[1], 50)
+
+        pmt_data = np.asarray(data["PMTData"])
+        self.assertEqual(pmt_data.shape[0], 2)
+        self.assertEqual(pmt_data.shape[1], 50)
+
+    def test_bpm_data_shapes(self):
+        mat = self._export_and_load()
+        data = self._data(mat)
+        bpmx = np.asarray(data["BPMXData"])
+        bpmy = np.asarray(data["BPMYData"])
+        self.assertEqual(bpmx.shape[0], 2)
+        self.assertEqual(bpmx.shape[1], 50)
+        self.assertEqual(bpmy.shape[0], 2)
+
+    def test_pos_and_signal_present(self):
+        mat = self._export_and_load()
+        data = self._data(mat)
+        pos = data["pos"][0, 0]
+        signal = data["signal"][0, 0]
+        pos_x = np.asarray(pos["x"]).ravel()
+        sig_x = np.asarray(signal["x"]).ravel()
+        self.assertEqual(len(pos_x), 50)
+        self.assertEqual(len(sig_x), 50)
+        self.assertTrue(np.all(pos_x > 0))
+
+    def _get_beam(self, mat):
+        data = self._data(mat)
+        return data["beam"][0, 0][0, 0]
+
+    def test_beam_struct_method(self):
+        mat = self._export_and_load()
+        beam = self._get_beam(mat)
+        method = str(beam["method"].ravel()[0])
+        self.assertEqual(method, "Gaussian")
+
+    def test_beam_stats_shape(self):
+        mat = self._export_and_load()
+        beam = self._get_beam(mat)
+        stats = np.asarray(beam["stats"]).ravel()
+        self.assertEqual(len(stats), 6)
+
+    def test_beam_profx_is_3xN(self):
+        mat = self._export_and_load()
+        beam = self._get_beam(mat)
+        profx = np.asarray(beam["profx"])
+        self.assertEqual(profx.shape[0], 3)
+        self.assertEqual(profx.shape[1], 50)
+
+    def test_beam_stats_contain_rms_values(self):
+        mat = self._export_and_load()
+        beam = self._get_beam(mat)
+        stats = np.asarray(beam["stats"]).ravel()
+        self.assertAlmostEqual(stats[2], 353.5, places=1)
+        self.assertAlmostEqual(stats[3], 212.1, places=1)
+
+    def test_select_pmt_is_one_based(self):
+        mat = self._export_and_load()
+        data = self._data(mat)
+        self.assertEqual(float(data["selectPMT"][0, 0]), 1.0)
+
+    def test_single_profile_active(self):
+        result = _make_analysis_result(active_profiles=("x",))
+        mat = self._export_and_load(result)
+        data = self._data(mat)
+        wire_dir = data["wireDir"][0, 0]
+        self.assertTrue(bool(wire_dir["x"][0, 0]))
+        self.assertFalse(bool(wire_dir["y"][0, 0]))
+
+    def test_no_bpms(self):
+        result = _make_analysis_result(include_bpms=False)
+        mat = self._export_and_load(result)
+        data = self._data(mat)
+        bpm_list = data["BPMList"].ravel()
+        self.assertEqual(len(bpm_list), 0)
+
+    def test_beam_pv_structure(self):
+        mat = self._export_and_load()
+        data = self._data(mat)
+        beam_pv = data["beamPV"]
+        self.assertIsNotNone(beam_pv)
+
+    def test_to_mat_method_on_result(self):
+        with NamedTemporaryFile(suffix=".mat", delete=False) as f:
+            path = f.name
+        returned_path = self.result.to_mat(path)
+        self.assertEqual(returned_path, path)
+        mat = scipy.io.loadmat(path)
+        self.assertIn("data", mat)

--- a/tests/test_mat_export.py
+++ b/tests/test_mat_export.py
@@ -233,9 +233,8 @@ class TestAnalysisResultToMat(TestCase):
         mat = self._export_and_load()
         data = self._data(mat)
         wire_data = np.asarray(data["wireData"])
-        self.assertEqual(wire_data.ndim, 3)
+        self.assertEqual(wire_data.ndim, 2)
         self.assertEqual(wire_data.shape[0], 1)
-        self.assertEqual(wire_data.shape[2], 1)
         self.assertEqual(wire_data.shape[1], 50)
 
         pmt_data = np.asarray(data["PMTData"])

--- a/tests/test_mat_export.py
+++ b/tests/test_mat_export.py
@@ -36,7 +36,7 @@ def _make_analysis_result(
     signal_y = np.exp(-0.5 * ((positions_y - 17000) / 300) ** 2)
 
     raw_data = {
-        "WIRE:LI21:285": positions_x,
+        "WIRE:TEST:285": positions_x,
         "PMT:LI21:100": signal_x * 1000,
         "PMT:LI21:200": signal_x * 800,
     }
@@ -57,7 +57,7 @@ def _make_analysis_result(
         scan_ranges["y"] = (15000, 19000)
 
     metadata = MeasurementMetadata(
-        wire_name="WIRE:LI21:285",
+        wire_name="WIRE:TEST:285",
         area="TEST",
         beampath="CU_HXR",
         detectors=["PMT:LI21:100", "PMT:LI21:200"],
@@ -188,8 +188,8 @@ class TestAnalysisResultToMat(TestCase):
     def test_scalar_string_fields(self):
         mat = self._export_and_load()
         data = self._data(mat)
-        self.assertEqual(str(data["name"][0]), "WIRE:LI21:285")
-        self.assertEqual(str(data["wireName"][0]), "WIRE:LI21:285")
+        self.assertEqual(str(data["name"][0]), "WIRE:TEST:285")
+        self.assertEqual(str(data["wireName"][0]), "WIRE:TEST:285")
         self.assertEqual(str(data["wireMode"][0]), "wire")
         self.assertEqual(str(data["beampath"][0]), "CU_HXR")
 

--- a/tests/test_mat_export.py
+++ b/tests/test_mat_export.py
@@ -58,7 +58,7 @@ def _make_analysis_result(
 
     metadata = MeasurementMetadata(
         wire_name="WIRE:LI21:285",
-        area="LI21",
+        area="TEST",
         beampath="CU_HXR",
         detectors=["PMT:LI21:100", "PMT:LI21:200"],
         default_detector="PMT:LI21:100",


### PR DESCRIPTION
This pull request adds comprehensive unit tests for the MATLAB `.mat` export functionality and introduces a new convenience method to the `WireMeasurementAnalysisResult` class for exporting analysis results. The main focus is on ensuring the correctness and compatibility of `.mat` file exports, including detailed checks of the exported data structure and values.

**MATLAB Export Functionality and Testing:**

* Added a new method `to_mat` to the `WireMeasurementAnalysisResult` class, providing a simple interface to export results as MATLAB `.mat` files compatible with `wirescan_gui`.
* Introduced a new test module `tests/test_mat_export.py` that:
  - Provides synthetic test data generation for analysis results.
  - Includes unit tests for the `datetime_to_matlab_datenum` conversion utility.
  - Thoroughly validates the structure and content of `.mat` files produced by `analysis_result_to_mat`, checking field presence, data shapes, and value correctness.
  - Tests edge cases such as results with single profiles, missing BPMs, and method integration via the new `to_mat` method.