### PR TITLE
[BUGFIX] Fix HDF5 save crash on `None` metadata fields

### DIFF
--- a/slac_measurements/wires/collection/results.py
+++ b/slac_measurements/wires/collection/results.py
@@ -86,8 +86,10 @@ class WireMeasurementCollectionResult(BeamProfileCollectionResult):
         if meta.buffer_number is not None:
             group.attrs["buffer_number"] = meta.buffer_number
         group.attrs["area"] = meta.area
-        group.attrs["beampath"] = meta.beampath
-        group.attrs["default_detector"] = meta.default_detector
+        if meta.beampath is not None:
+            group.attrs["beampath"] = meta.beampath
+        if meta.default_detector is not None:
+            group.attrs["default_detector"] = meta.default_detector
         if meta.rms_detector is not None:
             group.attrs["rms_detector"] = meta.rms_detector
         if meta.timestamp is not None:
@@ -99,10 +101,11 @@ class WireMeasurementCollectionResult(BeamProfileCollectionResult):
             group.attrs["notes"] = meta.notes
 
         # Store list of detectors
-        group.create_dataset(
-            "detectors",
-            data=np.array(meta.detectors, dtype="S"),
-        )
+        if meta.detectors is not None:
+            group.create_dataset(
+                "detectors",
+                data=np.array(meta.detectors, dtype="S"),
+            )
 
         # Store scan ranges as a structured dataset
         scan_ranges_group = group.create_group("scan_ranges")
@@ -166,8 +169,8 @@ def _load_metadata(group: h5py.Group) -> MeasurementMetadata:
     wire_name = group.attrs["wire_name"]
     buffer_number = group.attrs.get("buffer_number", None)
     area = group.attrs["area"]
-    beampath = group.attrs["beampath"]
-    default_detector = group.attrs["default_detector"]
+    beampath = group.attrs.get("beampath", None)
+    default_detector = group.attrs.get("default_detector", None)
     rms_detector = group.attrs.get("rms_detector", None)
     timestamp_str = group.attrs.get("timestamp", None)
     timestamp = (
@@ -178,7 +181,11 @@ def _load_metadata(group: h5py.Group) -> MeasurementMetadata:
     notes = group.attrs.get("notes", None)
 
     # Load detectors list
-    detectors = [d.decode() if isinstance(d, bytes) else d for d in group["detectors"]]
+    detectors = None
+    if "detectors" in group:
+        detectors = [
+            d.decode() if isinstance(d, bytes) else d for d in group["detectors"]
+        ]
 
     # Load scan ranges
     scan_ranges = {}

--- a/tests/test_wire_scan.py
+++ b/tests/test_wire_scan.py
@@ -170,3 +170,34 @@ class WireBeamProfileMeasurementTest(TestCase):
             loaded = load_from_h5(outpath)
 
         self.assertEqual(loaded.metadata.buffer_number, 7)
+
+    def test_collection_result_round_trip_with_none_optional_fields(self):
+        metadata = MeasurementMetadata(
+            wire_name="WIRE:TEST:100",
+            area="L3",
+            beampath=None,
+            detectors=None,
+            default_detector=None,
+            scan_ranges={"x": (100, 500), "y": (800, 1200)},
+            active_profiles=["x", "y"],
+            install_angle=45.0,
+        )
+        collection_result = WireMeasurementCollectionResult(
+            raw_data={"WIRE:TEST:100": np.array([100.0, 200.0, 500.0])},
+            metadata=metadata,
+        )
+
+        with TemporaryDirectory() as tmpdir:
+            outpath = f"{tmpdir}/collection_result.h5"
+            collection_result.save_to_h5(outpath)
+            loaded = load_from_h5(outpath)
+
+        self.assertIsNone(loaded.metadata.beampath)
+        self.assertIsNone(loaded.metadata.detectors)
+        self.assertIsNone(loaded.metadata.default_detector)
+        self.assertEqual(loaded.metadata.wire_name, "WIRE:TEST:100")
+        self.assertEqual(loaded.metadata.area, "L3")
+        self.assertEqual(
+            loaded.metadata.scan_ranges, {"x": (100, 500), "y": (800, 1200)}
+        )
+        self.assertEqual(loaded.metadata.active_profiles, ["x", "y"])


### PR DESCRIPTION
In commit 2f8b58d (July 7), `beampath`, `default_detector`, and `detectors` were relaxed from required to optional on `MeasurementMetadata` to support beamless scans. However, `_save_metadata` was never updated to handle `None` values for these fields. Since h5py cannot write `None` as an attribute, every scan that hit this path raised a `TypeError`. The exception was caught by the try/except in `_run_device_scan`, logged to the registry as `status="error"`, and re-raised so no H5 file was ever written.

The fix guards those three fields with `if is not None` checks (matching the existing pattern for `buffer_number` and `rms_detector`), updates `_load_metadata` to tolerate their absence when reading files back, and adds a round-trip test with all three set to `None` so this class of bug is caught going forward.